### PR TITLE
Advicely: plain-language UX pass for everyday users

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,17 +18,17 @@ const bodyFont = Space_Grotesk({
 export const metadata: Metadata = {
   title: "Advicely Reactor",
   description:
-    "Instant advice for 2026: one-click wisdom with adaptive tone, momentum tracking, and graceful fallback intelligence.",
+    "Get clear advice in one click, save what helps, and keep simple notes on what worked.",
   metadataBase: new URL("https://advicely.vercel.app"),
   openGraph: {
     title: "Advicely Reactor",
-    description: "Generate focused advice instantly and turn it into daily momentum.",
+    description: "One click gives you practical advice, a next step, and a quick reflection prompt.",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
     title: "Advicely Reactor",
-    description: "One click. Better advice. Repeatable momentum.",
+    description: "Clear advice in one click for everyday decisions.",
   },
 };
 

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -27,10 +27,10 @@ export default function OpenGraphImage() {
           Advicely Reactor
         </div>
         <div style={{ fontSize: 72, lineHeight: 1.03, maxWidth: 900, fontWeight: 700 }}>
-          One click. Better advice. Repeatable momentum.
+          Clear advice in one click.
         </div>
         <div style={{ fontSize: 30, opacity: 0.92 }}>
-          Adaptive tone, fallback intelligence, and daily progress loops.
+          A practical next step, a simple reflection, and support when you need it.
         </div>
       </div>
     ),

--- a/components/advice/advice-reactor.tsx
+++ b/components/advice/advice-reactor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import NextLink from "next/link";
 import { useRouter } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
@@ -21,13 +21,14 @@ import {
 } from "@chakra-ui/react";
 import { FiArrowRight, FiBookmark, FiCompass, FiRefreshCw, FiShare2, FiTrendingUp } from "react-icons/fi";
 import { adviceResponseSchema, type AdviceResponse, type ToneProfile } from "@/features/advice/contracts";
+import { getAdviceFitLabel, getAdviceSignalLabel, getToneProfileLabel } from "@/features/advice/presentation";
 import { createShareCard, getMomentumState, recordGeneration, saveAdviceCard } from "@/features/momentum/storage";
 
 const toneProfiles: Array<{ id: ToneProfile; label: string; hint: string }> = [
-  { id: "grounded", label: "Grounded", hint: "Practical and direct" },
-  { id: "bold", label: "Bold", hint: "Decisive and urgent" },
-  { id: "calm", label: "Calm", hint: "Steady and thoughtful" },
-  { id: "playful", label: "Playful", hint: "Light and energizing" },
+  { id: "grounded", label: "Practical", hint: "Straight and useful" },
+  { id: "bold", label: "Direct", hint: "Pushes you to act" },
+  { id: "calm", label: "Calm", hint: "Steady and low stress" },
+  { id: "playful", label: "Light", hint: "Friendly and energizing" },
 ];
 
 interface SnapshotStats {
@@ -103,13 +104,8 @@ export function AdviceReactor() {
   });
 
   const adviceCard = adviceResponse?.card;
-
-  const confidenceLabel = useMemo(() => {
-    if (!adviceCard) {
-      return "--";
-    }
-    return `${Math.round(adviceCard.confidence * 100)}%`;
-  }, [adviceCard]);
+  const adviceFitLabel = adviceCard ? getAdviceFitLabel(adviceCard.confidence) : "--";
+  const adviceSignalLabel = adviceCard ? getAdviceSignalLabel(adviceCard.errorState, adviceCard.fallbackUsed) : null;
 
   function handleGenerate() {
     setStatusMessage(null);
@@ -146,27 +142,27 @@ export function AdviceReactor() {
         >
           <Stack gap={3} maxW="3xl">
             <Badge alignSelf="flex-start" bg="ember.500" color="white" px={3} py={1} borderRadius="full">
-              Advice Reactor v4
+              Advicely v4
             </Badge>
             <Heading as="h1" id="main-content" fontSize={{ base: "3xl", md: "5xl" }} lineHeight="1.05">
-              Instant advice with enough intelligence to stay useful.
+              Get clear advice in one click.
             </Heading>
             <Text color="whiteAlpha.800" fontSize={{ base: "md", md: "lg" }}>
-              One click gives you a refined signal. Hybrid providers, quality scoring, and curated fallback keep the loop alive even when external APIs wobble.
+              Pick a style, tap Get Advice, and you will get one clear idea, one next step, and one question to help you follow through.
             </Text>
           </Stack>
           <SimpleGrid columns={3} gap={3} w={{ base: "100%", lg: "auto" }} minW={{ lg: "24rem" }}>
             <Box bg="whiteAlpha.120" p={4} borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300">
               <Text fontSize="xs" color="whiteAlpha.700" textTransform="uppercase" letterSpacing="0.08em">
-                Streak
+                Days used
               </Text>
               <Text fontSize="2xl" fontWeight="700">
-                {snapshotStats.streakDays}d
+                {snapshotStats.streakDays}
               </Text>
             </Box>
             <Box bg="whiteAlpha.120" p={4} borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300">
               <Text fontSize="xs" color="whiteAlpha.700" textTransform="uppercase" letterSpacing="0.08em">
-                Generations
+                Advice cards
               </Text>
               <Text fontSize="2xl" fontWeight="700">
                 {snapshotStats.totalGenerations}
@@ -174,7 +170,7 @@ export function AdviceReactor() {
             </Box>
             <Box bg="whiteAlpha.120" p={4} borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300">
               <Text fontSize="xs" color="whiteAlpha.700" textTransform="uppercase" letterSpacing="0.08em">
-                Saved
+                Saved ideas
               </Text>
               <Text fontSize="2xl" fontWeight="700">
                 {snapshotStats.savedCount}
@@ -187,7 +183,7 @@ export function AdviceReactor() {
           <Stack gap={4} gridColumn={{ xl: "span 2" }}>
             <Box bg="whiteAlpha.100" borderRadius="panel" p={5} borderWidth="1px" borderColor="whiteAlpha.300">
               <Text fontSize="sm" color="whiteAlpha.800" mb={3}>
-                Tone profile
+                Advice style
               </Text>
               <Stack gap={3}>
                 {toneProfiles.map((tone) => (
@@ -204,7 +200,7 @@ export function AdviceReactor() {
                     borderRadius="xl"
                     _hover={{ borderColor: "reactor.300", bg: tone.id === toneProfile ? "reactor.400" : "whiteAlpha.150" }}
                     _focusVisible={{ outline: "2px solid", outlineColor: "ember.300" }}
-                    aria-label={`Set tone profile to ${tone.label}`}
+                    aria-label={`Set advice style to ${tone.label}`}
                   >
                     <Box textAlign="left">
                       <Text fontWeight="700">{tone.label}</Text>
@@ -222,7 +218,7 @@ export function AdviceReactor() {
               <Button size="lg" bg="ember.500" color="white" onClick={handleGenerate} _hover={{ bg: "ember.400" }} _focusVisible={{ outline: "2px solid", outlineColor: "ember.200" }}>
                 <HStack>
                   <Icon as={FiRefreshCw} />
-                  <Text>Generate Advice</Text>
+                  <Text>Get Advice</Text>
                 </HStack>
               </Button>
               <Button
@@ -236,7 +232,7 @@ export function AdviceReactor() {
               >
                 <HStack>
                   <Icon as={FiBookmark} />
-                  <Text>Save</Text>
+                  <Text>Save This</Text>
                 </HStack>
               </Button>
             </SimpleGrid>
@@ -244,7 +240,7 @@ export function AdviceReactor() {
             <Button variant="ghost" justifyContent="flex-start" color="whiteAlpha.900" onClick={handleShare} disabled={!adviceCard} _hover={{ bg: "whiteAlpha.150" }}>
               <HStack>
                 <Icon as={FiShare2} />
-                <Text>Create share card</Text>
+                <Text>Share This Advice</Text>
               </HStack>
             </Button>
           </Stack>
@@ -267,16 +263,16 @@ export function AdviceReactor() {
               {adviceMutation.isPending ? (
                 <Stack h="100%" justify="center" align="center" gap={4}>
                   <Spinner size="lg" color="ember.300" />
-                  <Text color="whiteAlpha.800">Composing your next signal...</Text>
+                  <Text color="whiteAlpha.800">Finding your next useful step...</Text>
                 </Stack>
               ) : null}
 
               {adviceMutation.isError ? (
                 <Stack h="100%" justify="center" gap={4}>
                   <Heading as="h2" fontSize="2xl">
-                    Advice temporarily unavailable
+                    Advice is taking a moment
                   </Heading>
-                  <Text color="whiteAlpha.800">The service hit a rough patch. Trigger another generation to retry with fallback protection.</Text>
+                  <Text color="whiteAlpha.800">We could not reach live advice sources right now. Try again and we will use backup guidance if needed.</Text>
                   <Button alignSelf="flex-start" onClick={handleGenerate} bg="reactor.500">
                     <HStack>
                       <Icon as={FiRefreshCw} />
@@ -290,20 +286,14 @@ export function AdviceReactor() {
                 <Stack gap={6}>
                   <HStack wrap="wrap" gap={2}>
                     <Badge bg="reactor.500" color="white" borderRadius="full" px={3} py={1}>
-                      {adviceCard.toneProfile}
+                      {getToneProfileLabel(adviceCard.toneProfile)}
                     </Badge>
                     <Badge bg="whiteAlpha.200" color="white">
-                      Source: {adviceCard.sourceAttribution}
+                      {adviceFitLabel}
                     </Badge>
-                    <Badge bg="whiteAlpha.200" color="white">
-                      Confidence: {confidenceLabel}
-                    </Badge>
-                    <Badge bg="whiteAlpha.200" color="white">
-                      Freshness: {adviceCard.freshnessMinutes}m
-                    </Badge>
-                    {adviceCard.errorState ? (
+                    {adviceSignalLabel ? (
                       <Badge bg="ember.600" color="white">
-                        {adviceCard.errorState}
+                        {adviceSignalLabel}
                       </Badge>
                     ) : null}
                   </HStack>
@@ -316,13 +306,13 @@ export function AdviceReactor() {
                   <SimpleGrid columns={{ base: 1, md: 2 }} gap={4}>
                     <Box bg="whiteAlpha.120" borderRadius="xl" p={4}>
                       <Text fontSize="xs" color="whiteAlpha.700" textTransform="uppercase" letterSpacing="0.08em" mb={1}>
-                        Micro action
+                        Try this next
                       </Text>
                       <Text color="whiteAlpha.900">{adviceCard.microAction}</Text>
                     </Box>
                     <Box bg="whiteAlpha.120" borderRadius="xl" p={4}>
                       <Text fontSize="xs" color="whiteAlpha.700" textTransform="uppercase" letterSpacing="0.08em" mb={1}>
-                        Reflection
+                        Think about this
                       </Text>
                       <Text color="whiteAlpha.900">{adviceCard.reflectionPrompt}</Text>
                     </Box>
@@ -333,9 +323,9 @@ export function AdviceReactor() {
               {!adviceMutation.isPending && !adviceMutation.isError && !adviceCard ? (
                 <Stack h="100%" justify="center" align="flex-start" gap={4}>
                   <Heading as="h2" fontSize="2xl">
-                    Start the loop
+                    Ready when you are
                   </Heading>
-                  <Text color="whiteAlpha.800">Choose a tone profile and generate your first advice card.</Text>
+                  <Text color="whiteAlpha.800">Pick an advice style and press Get Advice.</Text>
                 </Stack>
               ) : null}
             </Box>
@@ -360,9 +350,9 @@ export function AdviceReactor() {
             >
               <HStack color="reactor.100" mb={2}>
                 <Icon as={FiTrendingUp} />
-                <Text fontWeight="700">Momentum</Text>
+                <Text fontWeight="700">Progress</Text>
               </HStack>
-              <Text color="whiteAlpha.800">Track streaks, reflections, and generation consistency.</Text>
+              <Text color="whiteAlpha.800">Review recent advice and save short notes about what worked.</Text>
             </Box>
           </NextLink>
 
@@ -377,9 +367,9 @@ export function AdviceReactor() {
             >
               <HStack color="ember.100" mb={2}>
                 <Icon as={FiBookmark} />
-                <Text fontWeight="700">Library</Text>
+                <Text fontWeight="700">Saved Advice</Text>
               </HStack>
-              <Text color="whiteAlpha.800">Curate your strongest advice cards by tone and confidence.</Text>
+              <Text color="whiteAlpha.800">Keep the advice you want to revisit later.</Text>
             </Box>
           </NextLink>
         </SimpleGrid>

--- a/components/library/library-grid.tsx
+++ b/components/library/library-grid.tsx
@@ -16,11 +16,19 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { FiArrowLeft, FiFilter, FiTrash2 } from "react-icons/fi";
+import { getAdviceFitLabel, getToneProfileLabel } from "@/features/advice/presentation";
 import { getMomentumState, removeSavedCard } from "@/features/momentum/storage";
 import { emptyMomentumState, type MomentumStateVM } from "@/features/momentum/contracts";
 import type { ToneProfile } from "@/features/advice/contracts";
 
 const toneOptions: Array<ToneProfile | "all"> = ["all", "grounded", "bold", "calm", "playful"];
+const toneOptionLabels: Record<ToneProfile | "all", string> = {
+  all: "All styles",
+  grounded: "Practical",
+  bold: "Direct",
+  calm: "Calm",
+  playful: "Light",
+};
 
 export function LibraryGrid() {
   const [state, setState] = useState<MomentumStateVM>(emptyMomentumState);
@@ -50,7 +58,7 @@ export function LibraryGrid() {
           <Button alignSelf="flex-start" variant="ghost">
             <HStack>
               <Icon as={FiArrowLeft} />
-              <Text>Back to reactor</Text>
+              <Text>Back to advice</Text>
             </HStack>
           </Button>
         </NextLink>
@@ -60,7 +68,7 @@ export function LibraryGrid() {
             Advice library
           </Heading>
           <Text color="whiteAlpha.800" maxW="2xl">
-            Your curated collection of cards worth reusing. Filter by tone and prune anything stale.
+            Save advice that actually helps, then come back to it when you need it.
           </Text>
         </Stack>
 
@@ -77,12 +85,12 @@ export function LibraryGrid() {
         >
           <Flex align="center" gap={2} color="whiteAlpha.900">
             <Icon as={FiFilter} />
-            <Text fontWeight="600">Tone filter</Text>
+            <Text fontWeight="600">Style</Text>
           </Flex>
           <select
             value={toneFilter}
             onChange={(event) => setToneFilter(event.target.value as ToneProfile | "all")}
-            aria-label="Filter saved advice by tone"
+            aria-label="Filter saved advice by style"
             style={{
               borderRadius: "0.7rem",
               border: "1px solid rgba(255,255,255,0.28)",
@@ -94,7 +102,7 @@ export function LibraryGrid() {
           >
             {toneOptions.map((tone) => (
               <option key={tone} value={tone} style={{ color: "#111827" }}>
-                {tone}
+                {toneOptionLabels[tone]}
               </option>
             ))}
           </select>
@@ -110,7 +118,7 @@ export function LibraryGrid() {
               borderColor="whiteAlpha.300"
               p={8}
             >
-              <Text color="whiteAlpha.800">No saved cards yet for this filter. Generate and save from the reactor to build your library.</Text>
+              <Text color="whiteAlpha.800">No saved advice in this style yet. Save cards from home to build your library.</Text>
             </Box>
           ) : null}
 
@@ -120,10 +128,10 @@ export function LibraryGrid() {
                 <Stack gap={2}>
                   <HStack>
                     <Badge bg="reactor.500" color="white">
-                      {card.toneProfile}
+                      {getToneProfileLabel(card.toneProfile)}
                     </Badge>
                     <Badge bg="whiteAlpha.200" color="white">
-                      {Math.round(card.confidence * 100)}%
+                      {getAdviceFitLabel(card.confidence)}
                     </Badge>
                   </HStack>
                   <Heading as="h2" size="md">
@@ -142,7 +150,7 @@ export function LibraryGrid() {
                 {card.advice}
               </Text>
               <Text mt={3} color="whiteAlpha.700" fontSize="sm">
-                Saved {new Date(card.savedAt).toLocaleString()} · Source {card.source}
+                Saved {new Date(card.savedAt).toLocaleString()}
               </Text>
             </Box>
           ))}

--- a/components/momentum/momentum-dashboard.tsx
+++ b/components/momentum/momentum-dashboard.tsx
@@ -22,8 +22,8 @@ import { addReflection, getMomentumState } from "@/features/momentum/storage";
 import { emptyMomentumState, type MomentumStateVM } from "@/features/momentum/contracts";
 
 const reflectionFormSchema = z.object({
-  adviceId: z.string().min(1, "Pick a recent advice entry."),
-  reflection: z.string().trim().min(12, "Reflection should be at least 12 characters.").max(280),
+  adviceId: z.string().min(1, "Choose an advice card first."),
+  reflection: z.string().trim().min(12, "Write at least 12 characters so this note is useful.").max(280),
 });
 
 type ReflectionFormValues = z.infer<typeof reflectionFormSchema>;
@@ -66,24 +66,24 @@ export function MomentumDashboard() {
           <Button alignSelf="flex-start" variant="ghost">
             <HStack>
               <Icon as={FiArrowLeft} />
-              <Text>Back to reactor</Text>
+              <Text>Back to advice</Text>
             </HStack>
           </Button>
         </NextLink>
 
         <Stack gap={2}>
           <Heading as="h1" id="main-content" fontSize={{ base: "3xl", md: "5xl" }}>
-            Momentum board
+            Your progress
           </Heading>
           <Text color="whiteAlpha.800" maxW="2xl">
-            Convert advice into behavior by tracking streak consistency and reflection quality.
+            Keep a simple record of what you have tried and what helped.
           </Text>
         </Stack>
 
         <SimpleGrid columns={{ base: 1, md: 4 }} gap={4}>
           <Box bg="whiteAlpha.120" borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300" p={4}>
             <Text color="whiteAlpha.700" fontSize="xs" textTransform="uppercase" letterSpacing="0.08em">
-              Active streak
+              Days practiced
             </Text>
             <Text fontSize="3xl" fontWeight="700">
               {state.streakDays} days
@@ -91,7 +91,7 @@ export function MomentumDashboard() {
           </Box>
           <Box bg="whiteAlpha.120" borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300" p={4}>
             <Text color="whiteAlpha.700" fontSize="xs" textTransform="uppercase" letterSpacing="0.08em">
-              Total generations
+              Advice sessions
             </Text>
             <Text fontSize="3xl" fontWeight="700">
               {state.totalGenerations}
@@ -99,7 +99,7 @@ export function MomentumDashboard() {
           </Box>
           <Box bg="whiteAlpha.120" borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300" p={4}>
             <Text color="whiteAlpha.700" fontSize="xs" textTransform="uppercase" letterSpacing="0.08em">
-              Saved cards
+              Saved advice
             </Text>
             <Text fontSize="3xl" fontWeight="700">
               {state.savedCards.length}
@@ -107,7 +107,7 @@ export function MomentumDashboard() {
           </Box>
           <Box bg="whiteAlpha.120" borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300" p={4}>
             <Text color="whiteAlpha.700" fontSize="xs" textTransform="uppercase" letterSpacing="0.08em">
-              Reflections
+              Notes written
             </Text>
             <Text fontSize="3xl" fontWeight="700">
               {reflectionCount}
@@ -120,12 +120,12 @@ export function MomentumDashboard() {
             <HStack mb={4} color="reactor.100">
               <Icon as={FiZap} />
               <Heading as="h2" size="md">
-                Recent generations
+                Recent advice
               </Heading>
             </HStack>
             <Stack gap={3} maxH="23rem" overflowY="auto" pr={1}>
               {state.generatedHistory.length === 0 ? (
-                <Text color="whiteAlpha.700">Generate your first advice card on the reactor page.</Text>
+                <Text color="whiteAlpha.700">Generate your first advice card from the home page.</Text>
               ) : null}
               {state.generatedHistory.map((item) => (
                 <Box key={item.id} borderWidth="1px" borderColor="whiteAlpha.300" borderRadius="xl" p={3} bg="whiteAlpha.100">
@@ -147,17 +147,17 @@ export function MomentumDashboard() {
             <HStack mb={4} color="ember.100">
               <Icon as={FiEdit3} />
               <Heading as="h2" size="md">
-                Reflection capture
+                Add a quick note
               </Heading>
             </HStack>
 
             <Stack gap={4}>
               <Box>
                 <Text mb={2} color="whiteAlpha.800">
-                  Advice entry
+                  Advice card
                 </Text>
                 <select
-                  aria-label="Advice entry"
+                  aria-label="Advice card"
                   style={{
                     width: "100%",
                     borderRadius: "0.75rem",
@@ -169,7 +169,7 @@ export function MomentumDashboard() {
                   {...form.register("adviceId")}
                 >
                   <option value="" style={{ color: "#1f2937" }}>
-                    Select a recent card
+                    Choose a recent card
                   </option>
                   {historyOptions.map((item) => (
                     <option key={item.id} value={item.id} style={{ color: "#1f2937" }}>
@@ -186,11 +186,11 @@ export function MomentumDashboard() {
 
               <Box>
                 <Text mb={2} color="whiteAlpha.800">
-                  Reflection
+                  What happened after trying it?
                 </Text>
                 <textarea
                   rows={5}
-                  aria-label="Reflection"
+                  aria-label="Outcome note"
                   style={{
                     width: "100%",
                     borderRadius: "0.75rem",
@@ -199,7 +199,7 @@ export function MomentumDashboard() {
                     color: "white",
                     padding: "0.75rem",
                   }}
-                  placeholder="Write what changed after applying the advice..."
+                  placeholder="Write what you tried and what happened..."
                   {...form.register("reflection")}
                 />
                 {form.formState.errors.reflection ? (
@@ -213,7 +213,7 @@ export function MomentumDashboard() {
                 <Button type="submit" bg="reactor.500" color="white" _hover={{ bg: "reactor.400" }}>
                   <HStack>
                     <Icon as={FiCheckCircle} />
-                    <Text>Save reflection</Text>
+                    <Text>Save note</Text>
                   </HStack>
                 </Button>
                 {savedMessage ? (

--- a/components/share/share-experience.tsx
+++ b/components/share/share-experience.tsx
@@ -14,6 +14,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { FiArrowLeft, FiCopy } from "react-icons/fi";
+import { getAdviceFitLabel, getToneProfileLabel } from "@/features/advice/presentation";
 import { getShareCardById } from "@/features/momentum/storage";
 import type { ShareCardVM } from "@/features/momentum/contracts";
 
@@ -51,7 +52,7 @@ export function ShareExperience({ shareId }: ShareExperienceProps) {
           <Button alignSelf="flex-start" variant="ghost">
             <HStack>
               <Icon as={FiArrowLeft} />
-              <Text>Back to reactor</Text>
+              <Text>Back to advice</Text>
             </HStack>
           </Button>
         </NextLink>
@@ -66,10 +67,10 @@ export function ShareExperience({ shareId }: ShareExperienceProps) {
           >
             <HStack gap={2} mb={4}>
               <Badge bg="reactor.500" color="white" px={3} py={1} borderRadius="full">
-                {shareCard.toneProfile}
+                {getToneProfileLabel(shareCard.toneProfile)}
               </Badge>
               <Badge bg="whiteAlpha.200" color="white" px={3} py={1} borderRadius="full">
-                {Math.round(shareCard.confidence * 100)}% confidence
+                {getAdviceFitLabel(shareCard.confidence)}
               </Badge>
             </HStack>
             <Heading as="h1" id="main-content" fontSize={{ base: "3xl", md: "5xl" }} lineHeight="1.05">
@@ -79,7 +80,7 @@ export function ShareExperience({ shareId }: ShareExperienceProps) {
               {shareCard.advice}
             </Text>
             <Text mt={4} color="whiteAlpha.700" fontSize="sm">
-              Generated from {shareCard.source} · {new Date(shareCard.createdAt).toLocaleString()}
+              Created {new Date(shareCard.createdAt).toLocaleString()}
             </Text>
 
             <Button mt={6} onClick={handleCopy} bg="ember.500" color="white" _hover={{ bg: "ember.400" }}>
@@ -97,14 +98,14 @@ export function ShareExperience({ shareId }: ShareExperienceProps) {
         ) : (
           <Box bg="whiteAlpha.120" borderRadius="panel" borderWidth="1px" borderColor="whiteAlpha.300" p={8}>
             <Heading as="h1" id="main-content" size="lg">
-              Share card not found
+              We could not find that share card
             </Heading>
             <Text mt={3} color="whiteAlpha.800">
-              This share card may have expired from local storage. Generate a new card and create a fresh share link.
+              It may have been cleared from this browser. Generate a new card and share again.
             </Text>
             <NextLink href="/">
               <Button mt={5} bg="reactor.500">
-                Generate new advice
+                Get new advice
               </Button>
             </NextLink>
           </Box>

--- a/features/advice/presentation.ts
+++ b/features/advice/presentation.ts
@@ -1,0 +1,48 @@
+import type { AdviceErrorState, ToneProfile } from "@/features/advice/contracts";
+
+const toneProfileLabels: Record<ToneProfile, string> = {
+  grounded: "Practical",
+  bold: "Direct",
+  calm: "Calm",
+  playful: "Light",
+};
+
+const adviceErrorLabels: Record<AdviceErrorState, string> = {
+  unavailable: "Live sources unavailable",
+  stale: "Using older source data",
+  partial: "Using backup guidance",
+  rate_limited: "Sources are busy right now",
+  invalid_payload: "Source data had an issue",
+};
+
+export function getToneProfileLabel(toneProfile: ToneProfile): string {
+  return toneProfileLabels[toneProfile];
+}
+
+export function getAdviceFitLabel(confidence: number): string {
+  if (confidence >= 0.85) {
+    return "Strong fit";
+  }
+
+  if (confidence >= 0.7) {
+    return "Good fit";
+  }
+
+  if (confidence >= 0.55) {
+    return "Worth trying";
+  }
+
+  return "Try and adapt";
+}
+
+export function getAdviceSignalLabel(errorState: AdviceErrorState | null, fallbackUsed: boolean): string | null {
+  if (errorState) {
+    return adviceErrorLabels[errorState];
+  }
+
+  if (fallbackUsed) {
+    return "Using backup guidance";
+  }
+
+  return null;
+}

--- a/features/advice/tone.ts
+++ b/features/advice/tone.ts
@@ -10,24 +10,24 @@ export interface TonedAdvice {
 
 const toneBlueprint: Record<ToneProfile, { headline: string; microAction: string; reflectionPrompt: string }> = {
   grounded: {
-    headline: "Practical Signal",
-    microAction: "Commit to one concrete next step you can finish in 10 minutes.",
-    reflectionPrompt: "What would make this advice easier to execute today?",
+    headline: "Practical Next Step",
+    microAction: "Choose one step you can finish in the next 10 minutes.",
+    reflectionPrompt: "What might block this, and how can you make it easier?",
   },
   bold: {
-    headline: "Pressure Test",
-    microAction: "Do the uncomfortable action first and measure what changes.",
-    reflectionPrompt: "Which fear is pretending to be strategy right now?",
+    headline: "Clear Push Forward",
+    microAction: "Do the hardest useful step first, even if it feels uncomfortable.",
+    reflectionPrompt: "If you stopped overthinking, what would you do next?",
   },
   calm: {
-    headline: "Steady Reset",
-    microAction: "Take one slow breath, then move with deliberate pacing.",
-    reflectionPrompt: "What outcome matters if you remove urgency from this moment?",
+    headline: "Steady Advice",
+    microAction: "Take one slow breath, then take a small step at a steady pace.",
+    reflectionPrompt: "What would this look like at a pace you can sustain?",
   },
   playful: {
-    headline: "Momentum Spark",
-    microAction: "Gamify the next move and reward yourself for launching quickly.",
-    reflectionPrompt: "How can you make this step feel lighter without lowering quality?",
+    headline: "Fresh Perspective",
+    microAction: "Make the next step tiny and enjoyable so you actually begin.",
+    reflectionPrompt: "How can you make this easier to start right now?",
   },
 };
 
@@ -57,7 +57,7 @@ export function applyToneProfile(baseAdvice: string, toneProfile: ToneProfile): 
   if (toneProfile === "playful") {
     return {
       headline: blueprint.headline,
-      advice: `${cleaned} Treat it like a small quest.`,
+      advice: `${cleaned} Keep it light and start small.`,
       microAction: blueprint.microAction,
       reflectionPrompt: blueprint.reflectionPrompt,
     };

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,7 @@ const securityHeaders = [
 const nextConfig: NextConfig = {
   typedRoutes: true,
   poweredByHeader: false,
+  allowedDevOrigins: ["localhost", "127.0.0.1"],
   async headers() {
     return [
       {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,3 +4,13 @@
 - What went wrong: The prior rewrite drifted away from the original one-click advice identity and felt too generic.
 - Root cause: Product intent was translated into broad coaching patterns without preserving the core instant-advice loop as the dominant interaction.
 - Prevention rule: For each product rewrite, lock the primary loop in tests and README first, then reject any UI changes that demote that loop from first-screen focus.
+
+## 2026-03-04
+- What went wrong: User-facing copy exposed internal system language and game-like framing that confused normal users.
+- Root cause: Internal confidence/source/error concepts were surfaced directly in UI text instead of being translated into plain-language guidance.
+- Prevention rule: Any surface copy touching API diagnostics must pass a plain-language review and include an e2e assertion that technical labels are not shown to end users.
+
+## 2026-03-04
+- What went wrong: Verification briefly showed a false lint failure.
+- Root cause: Lint and Playwright were run in parallel, and Playwright rotated `test-results` during ESLint file walking.
+- Prevention rule: Run lint/typecheck/test/e2e/build sequentially for final evidence to avoid filesystem race conditions.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,3 +30,16 @@
   - Console errors resolved after Chakra hydration hardening (`--webpack` scripts + hydration-safe client state initialization).
   - Mobile viewport check (`390x844`) confirmed responsive route rendering on `/`, `/momentum`, `/library`.
   - Trace summary on `/`: LCP `408ms`, CLS `0.00` (no throttling).
+
+## 2026-03-04 Copy Clarity and Everyday-Use Pass (`codex/ux-copy-clarity`)
+- [x] Replace technical and game-jargon copy on `/` with plain-language guidance.
+- [x] Translate confidence/error/internal-source surfacing into user-friendly labels.
+- [x] Reframe `/momentum`, `/library`, and `/share/[id]` language for regular users.
+- [x] Keep API/domain contracts stable while adding shared UI presentation helpers.
+- [x] Update e2e assertions to new primary headings and CTA language.
+- [x] Run verification ladder: `pnpm run lint`, `pnpm run typecheck`, `pnpm run test`, `pnpm run test:e2e`, `pnpm run build`.
+
+### Verification Notes
+- Final sequential ladder passed: `pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run test:e2e && pnpm run build && pnpm run audit:high`.
+- `pnpm run check` passed.
+- Next.js dev-origin warning addressed via `allowedDevOrigins` in `next.config.ts` (`localhost`, `127.0.0.1`).

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -3,16 +3,18 @@ import { expect, test } from "@playwright/test";
 test("primary advice reactor flow works", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: /instant advice with enough intelligence to stay useful/i })).toBeVisible();
-  await expect(page.getByRole("button", { name: /generate advice/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /get clear advice in one click/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /get advice/i })).toBeVisible();
 
-  await page.getByRole("button", { name: /bold/i }).click();
-  await page.getByRole("button", { name: /generate advice/i }).click();
+  await page.getByRole("button", { name: /direct/i }).click();
+  await page.getByRole("button", { name: /get advice/i }).click();
 
-  await expect(page.getByText(/micro action/i)).toBeVisible();
-  await expect(page.getByRole("link", { name: /momentum/i })).toBeVisible();
-  await expect(page.getByRole("link", { name: /library/i })).toBeVisible();
+  await expect(page.getByText(/try this next/i)).toBeVisible();
+  await expect(page.getByText(/source:/i)).toHaveCount(0);
+  await expect(page.getByText(/confidence:/i)).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /progress/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /saved advice/i })).toBeVisible();
 
-  await page.getByRole("link", { name: /momentum/i }).click();
-  await expect(page.getByRole("heading", { name: /momentum board/i })).toBeVisible();
+  await page.getByRole("link", { name: /progress/i }).click();
+  await expect(page.getByRole("heading", { name: /your progress/i })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Rewrote technical and game-like copy into plain-language guidance across Home, Progress, Library, and Share.
- Translated internal confidence, provider, and error signals into user-friendly labels via a shared presentation helper.
- Updated tone output wording so advice feels practical and useful for regular users.
- Aligned metadata and OG copy with the new user-facing voice.
- Added Next.js `allowedDevOrigins` config to remove local/e2e cross-origin warning noise.
- Added e2e guardrails to prevent internal labels like `Source:` and `Confidence:` from reappearing in the public UI.

## Verification
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run test:e2e`
- `pnpm run build`
- `pnpm run audit:high`

All commands passed on branch `codex/ux-copy-clarity`.
