### PR TITLE
Advicely polish pass: practical outputs and clearer UX semantics

### DIFF
--- a/components/advice/advice-studio.tsx
+++ b/components/advice/advice-studio.tsx
@@ -33,7 +33,6 @@ import {
 } from "@/features/advice/contracts";
 import {
   getAdviceBlockTitle,
-  getAdviceFitLabel,
   getAdviceSignalLabel,
   getDetailLabel,
   getIntentLabel,
@@ -246,7 +245,7 @@ export function AdviceStudio() {
 
                 <Box>
                   <Text fontSize="sm" color="gray.600" mb={2}>
-                    Advice type
+                    What kind of advice do you want?
                   </Text>
                   <SimpleGrid columns={{ base: 2, md: 3 }} gap={2}>
                     {intentOptions.map((option) => (
@@ -269,7 +268,7 @@ export function AdviceStudio() {
                 <SimpleGrid columns={{ base: 1, md: 2 }} gap={4}>
                   <Box>
                     <Text fontSize="sm" color="gray.600" mb={2}>
-                      Tone
+                      Voice
                     </Text>
                     <SimpleGrid columns={2} gap={2}>
                       {styleOptions.map((option) => (
@@ -291,7 +290,7 @@ export function AdviceStudio() {
 
                   <Box>
                     <Text fontSize="sm" color="gray.600" mb={2}>
-                      Detail
+                      Depth
                     </Text>
                     <SimpleGrid columns={3} gap={2}>
                       {detailOptions.map((option) => (
@@ -403,9 +402,6 @@ export function AdviceStudio() {
                   </Badge>
                   <Badge bg="gray.100" color="gray.700">
                     {getDetailLabel(latestCard.detail)}
-                  </Badge>
-                  <Badge bg="gray.100" color="gray.700">
-                    {getAdviceFitLabel(latestCard.confidence)}
                   </Badge>
                   {getAdviceSignalLabel(latestCard.errorState, latestCard.fallbackUsed) ? (
                     <Badge bg="signal.100" color="signal.900">

--- a/components/history/history-timeline.tsx
+++ b/components/history/history-timeline.tsx
@@ -20,7 +20,6 @@ import {
 import { FiArrowLeft, FiBookmark, FiCornerUpLeft, FiSearch, FiShare2 } from "react-icons/fi";
 import type { AdviceCardVM } from "@/features/advice/contracts";
 import {
-  getAdviceFitLabel,
   getDetailLabel,
   getIntentLabel,
   getSourceLabel,
@@ -146,7 +145,6 @@ export function HistoryTimeline() {
                       <Badge bg="utility.600" color="white">{getIntentLabel(card.intent)}</Badge>
                       <Badge bg="gray.100" color="gray.700">{getStyleLabel(card.style)}</Badge>
                       <Badge bg="gray.100" color="gray.700">{getDetailLabel(card.detail)}</Badge>
-                      <Badge bg="gray.100" color="gray.700">{getAdviceFitLabel(card.confidence)}</Badge>
                       <Badge bg="gray.100" color="gray.700">{getSourceLabel(card.source)}</Badge>
                     </HStack>
                     <Heading as="h2" size="md" color="gray.900">

--- a/components/saved/saved-library.tsx
+++ b/components/saved/saved-library.tsx
@@ -21,7 +21,6 @@ import {
 import { FiArrowLeft, FiSearch, FiShare2, FiTrash2 } from "react-icons/fi";
 import type { AdviceIntent, AdviceProvider, AdviceStyle } from "@/features/advice/contracts";
 import {
-  getAdviceFitLabel,
   getDetailLabel,
   getIntentLabel,
   getSourceLabel,
@@ -251,7 +250,6 @@ export function SavedLibrary() {
                   <HStack wrap="wrap" gap={2}>
                     <Badge bg="utility.600" color="white">{getIntentLabel(card.intent)}</Badge>
                     <Badge bg="gray.100" color="gray.700">{getStyleLabel(card.style)}</Badge>
-                    <Badge bg="gray.100" color="gray.700">{getAdviceFitLabel(card.confidence)}</Badge>
                   </HStack>
                   <Heading as="h2" size="md" color="gray.900">
                     {card.headline}

--- a/components/share/share-experience.tsx
+++ b/components/share/share-experience.tsx
@@ -16,7 +16,6 @@ import {
 import { FiArrowLeft, FiCopy } from "react-icons/fi";
 import {
   getAdviceBlockTitle,
-  getAdviceFitLabel,
   getIntentLabel,
   getSourceLabel,
   getStyleLabel,
@@ -96,9 +95,6 @@ export function ShareExperience({ shareId }: ShareExperienceProps) {
               </Badge>
               <Badge bg="gray.100" color="gray.700" px={3} py={1} borderRadius="full">
                 {getStyleLabel(shareCard.card.style)}
-              </Badge>
-              <Badge bg="gray.100" color="gray.700" px={3} py={1} borderRadius="full">
-                {getAdviceFitLabel(shareCard.card.confidence)}
               </Badge>
             </HStack>
             <Heading as="h1" fontSize={{ base: "3xl", md: "5xl" }} lineHeight="1.05" color="gray.900">

--- a/features/advice/presentation.ts
+++ b/features/advice/presentation.ts
@@ -45,10 +45,10 @@ const errorLabels: Record<AdviceErrorState, string> = {
 
 const blockTitles: Record<AdviceBlockVM["type"], string> = {
   core_advice: "Advice",
-  steps: "Steps",
+  steps: "Next Steps",
   script: "Suggested Script",
   reframe: "Perspective",
-  caution: "Important",
+  caution: "Use Caution",
   checklist: "Checklist",
 };
 
@@ -66,22 +66,6 @@ export function getDetailLabel(detail: AdviceDetail): string {
 
 export function getSourceLabel(source: AdviceProvider): string {
   return sourceLabels[source];
-}
-
-export function getAdviceFitLabel(confidence: number): string {
-  if (confidence >= 0.85) {
-    return "Strong fit";
-  }
-
-  if (confidence >= 0.7) {
-    return "Good fit";
-  }
-
-  if (confidence >= 0.55) {
-    return "Worth trying";
-  }
-
-  return "Try and adapt";
 }
 
 export function getAdviceSignalLabel(

--- a/features/advice/quality.ts
+++ b/features/advice/quality.ts
@@ -1,4 +1,15 @@
 const blockedFragments = ["buy now", "click here", "http://", "https://"];
+const practicalVerbPattern =
+  /\b(start|choose|write|ask|set|plan|break|call|send|schedule|draft|list|pause|breathe|review|decide|test|clarify|define|focus|limit|prioritize|explain|communicate|commit|simplify|track|compare)\b/i;
+const secondPersonPattern = /\b(you|your)\b/i;
+const firstPersonPattern = /\b(i|me|my|mine)\b/i;
+const nonPracticalPatterns = [
+  /\bplot twist\b/i,
+  /\beverybody makes mistakes\b/i,
+  /\blook up at the stars\b/i,
+  /\bcarry on\b/i,
+  /\bit is what it is\b/i,
+];
 
 function repairMojibake(text: string): string {
   if (!/[ÃÂ][\u0080-\u00ff]/.test(text)) {
@@ -52,9 +63,28 @@ export function containsBlockedFragment(text: string): boolean {
   return blockedFragments.some((fragment) => lower.includes(fragment));
 }
 
+export function looksNonPractical(text: string): boolean {
+  return nonPracticalPatterns.some((pattern) => pattern.test(text));
+}
+
+export function hasPracticalVerb(text: string): boolean {
+  return practicalVerbPattern.test(text);
+}
+
 export function isLowQualityAdvice(text: string): boolean {
   const normalized = normalizeAdviceText(text);
-  return normalized.length < 18 || containsBlockedFragment(normalized) || computeQualityScore(normalized) < 0.45;
+  const isSelfReflective = firstPersonPattern.test(normalized) && !secondPersonPattern.test(normalized);
+  const hasAttribution = /\s[-—]\s[A-Za-z]/.test(normalized);
+
+  return (
+    normalized.length < 18 ||
+    containsBlockedFragment(normalized) ||
+    looksNonPractical(normalized) ||
+    isSelfReflective ||
+    hasAttribution ||
+    !hasPracticalVerb(normalized) ||
+    computeQualityScore(normalized) < 0.45
+  );
 }
 
 export function summarizeAdvice(text: string, max = 88): string {

--- a/features/advice/shaping.ts
+++ b/features/advice/shaping.ts
@@ -4,7 +4,12 @@ import {
   type AdviceRequestVM,
   type AdviceStyle,
 } from "@/features/advice/contracts";
-import { normalizeAdviceText, summarizeAdvice } from "@/features/advice/quality";
+import {
+  hasPracticalVerb,
+  looksNonPractical,
+  normalizeAdviceText,
+  summarizeAdvice,
+} from "@/features/advice/quality";
 
 interface ShapedAdvice {
   headline: string;
@@ -13,13 +18,43 @@ interface ShapedAdvice {
 }
 
 const intentHeadlines: Record<AdviceIntent, string> = {
-  quick: "Quick Direction",
-  decision: "Decision Support",
-  communication: "Message Guidance",
-  planning: "Execution Plan",
-  stress: "Calm and Act",
-  general: "Useful Advice",
+  quick: "Quick Next Step",
+  decision: "Decision Guide",
+  communication: "Message Plan",
+  planning: "Action Plan",
+  stress: "Steady Next Move",
+  general: "Practical Guidance",
 };
+
+const intentSummaries: Record<AdviceIntent, string> = {
+  quick: "One clear move you can take right now.",
+  decision: "A structured way to choose without spiraling.",
+  communication: "Clear language you can use in real conversations.",
+  planning: "A simple sequence to move from idea to execution.",
+  stress: "A calmer way to reduce pressure and regain control.",
+  general: "Useful guidance you can apply immediately.",
+};
+
+const highRiskContextPattern = /\b(legal|medical|health|safety|danger|injury|financial|debt|tax|lawsuit|self-harm)\b/i;
+const stopwords = new Set([
+  "about",
+  "after",
+  "again",
+  "being",
+  "could",
+  "from",
+  "have",
+  "into",
+  "just",
+  "need",
+  "that",
+  "this",
+  "with",
+  "without",
+  "work",
+  "week",
+  "your",
+]);
 
 function titleFromContext(intent: AdviceIntent, context?: string): string {
   const fallback = intentHeadlines[intent];
@@ -36,18 +71,18 @@ function titleFromContext(intent: AdviceIntent, context?: string): string {
     return fallback;
   }
 
-  if (normalized.length <= 64) {
-    return normalized;
+  if (normalized.length <= 56) {
+    return `About: ${normalized}`;
   }
 
-  return `${normalized.slice(0, 61).trimEnd()}...`;
+  return `About: ${normalized.slice(0, 53).trimEnd()}...`;
 }
 
 function applyStyle(text: string, style: AdviceStyle): string {
   const cleaned = normalizeAdviceText(text);
 
   if (style === "direct") {
-    return cleaned.replace(/\b(maybe|perhaps|might)\b/gi, "");
+    return normalizeAdviceText(cleaned.replace(/\b(maybe|perhaps|might)\b/gi, ""));
   }
 
   if (style === "supportive") {
@@ -64,15 +99,99 @@ function applyStyle(text: string, style: AdviceStyle): string {
   return cleaned;
 }
 
+function fallbackCoreAdvice(request: AdviceRequestVM): string {
+  const contextText = request.context
+    ? request.context.trim().replace(/\s+/g, " ").slice(0, 120)
+    : null;
+
+  if (request.intent === "quick") {
+    return contextText
+      ? `Pick the smallest useful move for "${contextText}" and complete it within the next 10 minutes.`
+      : "Pick one useful task you can finish in 10 minutes and do it before switching context.";
+  }
+
+  if (request.intent === "decision") {
+    return "Choose the option that is easiest to test, easiest to reverse, and most likely to teach you something fast.";
+  }
+
+  if (request.intent === "communication") {
+    return contextText
+      ? "State your boundary in one sentence, then offer one realistic alternative with a date."
+      : "Say what you need in one sentence, then add one concrete next step.";
+  }
+
+  if (request.intent === "planning") {
+    return contextText
+      ? `Define what done looks like for "${contextText}", then split it into the next three concrete actions.`
+      : "Define what done looks like, then split the work into the next three concrete actions.";
+  }
+
+  if (request.intent === "stress") {
+    return "Lower pressure first, then pick one controllable action you can complete right now.";
+  }
+
+  return "Choose one practical action, do it now, then adjust based on what you learn.";
+}
+
+function keywords(text: string): Set<string> {
+  const raw = normalizeAdviceText(text).toLowerCase().match(/[a-z]{4,}/g) ?? [];
+  return new Set(raw.filter((word) => !stopwords.has(word)));
+}
+
+function isContextRelevant(advice: string, context?: string): boolean {
+  if (!context) {
+    return true;
+  }
+
+  const adviceKeywords = keywords(advice);
+  const contextKeywords = keywords(context);
+
+  if (contextKeywords.size === 0) {
+    return true;
+  }
+
+  for (const token of contextKeywords) {
+    if (adviceKeywords.has(token)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function resolveCoreAdvice(baseAdvice: string, request: AdviceRequestVM): string {
+  const styled = applyStyle(baseAdvice, request.style);
+
+  if (
+    looksNonPractical(styled) ||
+    !hasPracticalVerb(styled) ||
+    (request.context !== undefined && !isContextRelevant(styled, request.context))
+  ) {
+    return fallbackCoreAdvice(request);
+  }
+
+  return styled;
+}
+
 function planningSteps(context?: string): string[] {
   const scopeLine = context
     ? `Define what success means for: ${context.trim().replace(/\s+/g, " ").slice(0, 120)}.`
     : "Define what success looks like in one sentence.";
 
+  return [scopeLine, "Break the work into the next three concrete actions.", "Start the first action within the next 10 minutes."];
+}
+
+function quickSteps(context?: string): string[] {
+  if (context) {
+    return [
+      `Write one sentence for the real problem in: ${context.trim().replace(/\s+/g, " ").slice(0, 100)}.`,
+      "Do the smallest useful action in the next 10 minutes.",
+    ];
+  }
+
   return [
-    scopeLine,
-    "Break the work into the next three concrete actions.",
-    "Start the first action within the next 10 minutes.",
+    "Pick one thing that would make today easier.",
+    "Do the smallest useful step now, before opening new tasks.",
   ];
 }
 
@@ -80,16 +199,24 @@ function decisionChecklist(): string[] {
   return [
     "Compare impact, effort, and reversibility for each option.",
     "Prefer the option that gives fast feedback with lower downside.",
-    "Set a deadline for deciding so uncertainty does not drag on.",
+    "Set a deadline so uncertainty does not drag on.",
   ];
 }
 
 function communicationScript(context?: string): string {
-  const topic = context
-    ? context.trim().replace(/\s+/g, " ").slice(0, 120)
-    : "this";
+  if (context) {
+    return "Try saying: \"I want to be transparent about capacity this week. I can't take this on right now, but I can help with [specific alternative] by [date].\"";
+  }
 
-  return `Try saying: "I want to align on ${topic}. My request is [specific ask], and I can commit to [your contribution]."`;
+  return "Try saying: \"Here is what I can commit to now: [specific scope] by [date].\"";
+}
+
+function communicationChecklist(): string[] {
+  return [
+    "Lead with your request, not the full backstory.",
+    "Use one concrete example to make your point clear.",
+    "End with a specific next step and owner.",
+  ];
 }
 
 function stressReframe(context?: string): string {
@@ -97,7 +224,35 @@ function stressReframe(context?: string): string {
     return "Focus on one controllable step right now, not the entire problem at once.";
   }
 
-  return `Treat this as a sequence, not a cliff. For "${context.trim().slice(0, 120)}", choose the next controllable step only.`;
+  return `Treat this as a sequence, not a cliff. For "${context.trim().slice(0, 120)}", choose only the next controllable step.`;
+}
+
+function stressChecklist(): string[] {
+  return [
+    "Pause for 30 seconds to lower physical stress.",
+    "Name one thing you can control in the next hour.",
+    "Take that single step before evaluating everything else.",
+  ];
+}
+
+function deepBoostBlocks(request: AdviceRequestVM): AdviceBlockVM[] {
+  if (request.intent === "decision") {
+    return [{ type: "steps", items: ["List your top two options.", "Write one experiment for each option.", "Run the lowest-risk experiment first."] }];
+  }
+
+  if (request.intent === "planning") {
+    return [{ type: "checklist", items: ["Timebox the first action.", "Remove one distraction before starting.", "Review progress before adding more work."] }];
+  }
+
+  if (request.intent === "communication") {
+    return [{ type: "checklist", items: communicationChecklist() }];
+  }
+
+  if (request.intent === "stress") {
+    return [{ type: "checklist", items: stressChecklist() }];
+  }
+
+  return [{ type: "checklist", items: ["Keep the next step under 10 minutes.", "Observe what changed after acting.", "Adjust based on results, not mood."] }];
 }
 
 function detailCap(detail: AdviceRequestVM["detail"]): number {
@@ -109,7 +264,7 @@ function detailCap(detail: AdviceRequestVM["detail"]): number {
     return 3;
   }
 
-  return 5;
+  return 4;
 }
 
 function uniqueBlocks(blocks: AdviceBlockVM[]): AdviceBlockVM[] {
@@ -128,13 +283,21 @@ function uniqueBlocks(blocks: AdviceBlockVM[]): AdviceBlockVM[] {
   return result;
 }
 
+function buildSummary(intent: AdviceIntent, context?: string): string {
+  if (!context) {
+    return intentSummaries[intent];
+  }
+
+  return summarizeAdvice(`${intentSummaries[intent]} Focus: ${context.trim().replace(/\s+/g, " ")}`, 180);
+}
+
 export function buildAdaptiveAdvice(baseAdvice: string, request: AdviceRequestVM): ShapedAdvice {
-  const styledAdvice = applyStyle(baseAdvice, request.style);
+  const coreAdvice = resolveCoreAdvice(baseAdvice, request);
 
   const blocks: AdviceBlockVM[] = [
     {
       type: "core_advice",
-      text: styledAdvice,
+      text: coreAdvice,
     },
   ];
 
@@ -152,28 +315,28 @@ export function buildAdaptiveAdvice(baseAdvice: string, request: AdviceRequestVM
 
   if (request.intent === "stress") {
     blocks.push({ type: "reframe", text: stressReframe(request.context) });
-    blocks.push({
-      type: "caution",
-      text: "If this involves legal, medical, safety, or financial risk, verify with a qualified professional before acting.",
-    });
+
+    if (request.context && highRiskContextPattern.test(request.context)) {
+      blocks.push({
+        type: "caution",
+        text: "If this involves legal, medical, safety, or financial risk, verify with a qualified professional before acting.",
+      });
+    }
   }
 
-  if ((request.intent === "general" || request.intent === "quick") && request.context) {
-    blocks.push({ type: "steps", items: planningSteps(request.context).slice(1) });
+  if (request.intent === "general" || request.intent === "quick") {
+    blocks.push({ type: "steps", items: quickSteps(request.context) });
   }
 
-  if (request.detail === "deep" && request.intent !== "stress") {
-    blocks.push({
-      type: "caution",
-      text: "Pressure can distort judgment. Keep the next step small, observable, and easy to adjust.",
-    });
+  if (request.detail === "deep") {
+    blocks.push(...deepBoostBlocks(request));
   }
 
   const capped = uniqueBlocks(blocks).slice(0, detailCap(request.detail));
 
   return {
     headline: titleFromContext(request.intent, request.context),
-    summary: summarizeAdvice(styledAdvice, 150),
+    summary: buildSummary(request.intent, request.context),
     blocks: capped,
   };
 }

--- a/lib/api/providers/zen-quotes.ts
+++ b/lib/api/providers/zen-quotes.ts
@@ -39,9 +39,9 @@ export async function requestZenQuote(url: string, timeoutMs: number): Promise<P
     const quote = payload.data[0];
 
     return {
-      text: `${quote.q} — ${quote.a}`,
+      text: quote.q,
       source: "zen_quotes",
-      sourceAttribution: "ZenQuotes API",
+      sourceAttribution: `ZenQuotes API (${quote.a})`,
       confidence: 0.76,
       fallbackUsed: false,
       errorState: null,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -19,3 +19,8 @@
 - What went wrong: Dev runtime produced a Chakra hydration mismatch after switching to Turbopack mode.
 - Root cause: Emotion style injection order in this stack can diverge under Turbopack dev hydration.
 - Prevention rule: Keep `next dev --webpack` for this repo and verify browser console is clean via DevTools before finalizing UI work.
+
+## 2026-03-04
+- What went wrong: Advice cards surfaced non-practical quote content and generic warning labels that confused normal users.
+- Root cause: Provider acceptance heuristics overvalued grammar/length and shaping rules added context-agnostic blocks for deep mode.
+- Prevention rule: Require practical-language heuristics plus context relevance before accepting provider text, and enforce intent-specific block assertions in unit tests.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -47,3 +47,17 @@
   - console errors: none after switching dev to webpack mode
   - mobile/desktop route sanity: `/`, `/saved`, `/history`, `/share/[id]` checked
   - performance trace (`/`): LCP 147ms, CLS 0.00 (local lab run)
+
+## 2026-03-04 UI/UX Polish Pass
+- [x] Reproduced odd output states in Chrome DevTools MCP (`Quick + Deep` no-context and context mismatch scenarios)
+- [x] Tightened provider quality/relevance heuristics for practical output
+- [x] Reworked shaping to remove generic deep warning behavior and enforce actionable blocks
+- [x] Simplified end-user terminology (removed confidence-fit badges from primary surfaces)
+- [x] Revalidated desktop/mobile output sanity via DevTools snapshots
+
+### Polish Verification
+- `pnpm run check` (pass)
+- `pnpm run test:e2e` (pass)
+- `pnpm run docs:check` (pass)
+- `pnpm run audit:high` (pass)
+- DevTools MCP checks: no console errors; practical output verified for `quick/deep` and `communication/deep` flows

--- a/tests/unit/shaping-quality.test.ts
+++ b/tests/unit/shaping-quality.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { normalizeAdviceText, summarizeAdvice } from "@/features/advice/quality";
+import {
+  hasPracticalVerb,
+  isLowQualityAdvice,
+  normalizeAdviceText,
+  summarizeAdvice,
+} from "@/features/advice/quality";
 import { buildAdaptiveAdvice } from "@/features/advice/shaping";
 
 describe("quality utilities", () => {
@@ -12,6 +17,11 @@ describe("quality utilities", () => {
     const summarized = summarizeAdvice("A".repeat(200), 80);
     expect(summarized.length).toBeLessThanOrEqual(80);
     expect(summarized.endsWith("…")).toBe(true);
+  });
+
+  it("rejects non-practical platitudes", () => {
+    expect(isLowQualityAdvice('When something goes wrong in life, just shout "plot twist!" and carry on.')).toBe(true);
+    expect(hasPracticalVerb("Write one sentence and send the update now.")).toBe(true);
   });
 });
 
@@ -45,5 +55,21 @@ describe("adaptive advice shaping", () => {
     );
 
     expect(shaped.blocks.length).toBeLessThanOrEqual(2);
+  });
+
+  it("keeps quick deep responses actionable", () => {
+    const shaped = buildAdaptiveAdvice(
+      "Everybody makes mistakes.",
+      {
+        context: undefined,
+        intent: "quick",
+        style: "balanced",
+        detail: "deep",
+        avoidRecentHashes: [],
+      },
+    );
+
+    expect(shaped.blocks.some((block) => block.type === "steps")).toBe(true);
+    expect(shaped.blocks.some((block) => block.type === "caution")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
This PR applies a focused polish pass on Advicely’s core generation experience to fix awkward/low-value output semantics observed in real UI usage.

### What changed
- tightened advice-quality filtering to reject non-practical/jokey/attributed quote content
- added context relevance gating so context-driven requests do not surface unrelated quote text
- reworked shaping rules so deep mode adds useful intent-specific depth (not generic warnings)
- improved copy semantics:
  - `Advice type` -> `What kind of advice do you want?`
  - `Tone` -> `Voice`
  - `Detail` -> `Depth`
  - block title `Steps` -> `Next Steps`
  - block title `Important` -> `Use Caution`
- removed confidence-fit badges from primary surfaces for cleaner user-facing language
- refined communication script output to avoid awkward context echoing

## Files touched
- `features/advice/quality.ts`
- `features/advice/shaping.ts`
- `features/advice/presentation.ts`
- `lib/api/providers/zen-quotes.ts`
- `components/advice/advice-studio.tsx`
- `components/history/history-timeline.tsx`
- `components/saved/saved-library.tsx`
- `components/share/share-experience.tsx`
- `tests/unit/shaping-quality.test.ts`
- `tasks/todo.md`
- `tasks/lessons.md`

## Verification
- [x] `pnpm run check`
- [x] `pnpm run test:e2e`
- [x] `pnpm run docs:check`
- [x] `pnpm run audit:high`

## Chrome DevTools MCP validation
Validated on local app after changes:
- reproduced and resolved `Quick + Deep` no-context awkward output pattern
- validated context-heavy communication flow now returns relevant practical guidance
- confirmed no console errors during validation run
