### PR TITLE
Refocus Advicely copy on user value

### DIFF
--- a/components/draw/draw-studio.tsx
+++ b/components/draw/draw-studio.tsx
@@ -17,7 +17,7 @@ import {
   Text,
   Textarea,
 } from "@chakra-ui/react";
-import { FiBookmark, FiCopy, FiEye, FiLock, FiRefreshCw, FiShuffle } from "react-icons/fi";
+import { FiBookmark, FiCopy, FiEye, FiRefreshCw, FiShuffle } from "react-icons/fi";
 import { AppNav } from "@/components/app-nav";
 import { SourceCardView } from "@/components/source-card";
 import {
@@ -42,19 +42,19 @@ const modeOptions: DrawMode[] = ["mixed", "advice", "quote"];
 
 const heroSignals = [
   {
-    icon: FiEye,
-    title: "Clearly sourced",
-    body: "Every card tells you whether it came from AdviceSlip, ZenQuotes, or the Advicely Reserve.",
-  },
-  {
-    icon: FiLock,
-    title: "Private by default",
-    body: "Notes stay in this browser unless you deliberately include them when copying a card.",
-  },
-  {
     icon: FiShuffle,
-    title: "Worth saving",
-    body: "Draw freely, keep what lands, and revisit it later through your library or recent trail.",
+    title: "Fresh every time",
+    body: "Switch between advice, quotes, or a mixed deck whenever you want a different kind of pull.",
+  },
+  {
+    icon: FiBookmark,
+    title: "Worth keeping",
+    body: "Save the cards that land, then come back to them later with your own note beside them.",
+  },
+  {
+    icon: FiEye,
+    title: "Source included",
+    body: "Every card keeps its attribution so you always know whether it came from a live source or the reserve.",
   },
 ] as const;
 
@@ -165,10 +165,10 @@ export function DrawStudio() {
             Advicely
           </Badge>
           <Heading as="h1" fontSize={{ base: "4xl", md: "6xl" }} color="ink.800" lineHeight="0.94">
-            A premium draw deck for random advice and quotes.
+            Find a line worth keeping.
           </Heading>
           <Text color="ink.600" fontSize={{ base: "md", md: "lg" }} maxW="3xl">
-            Built for honest browsing, quiet collecting, and clean copying. No fake coaching layer, no hidden source switching, no private notes leaving your browser.
+            Draw a piece of advice or a quote, save the ones that stick, and keep a private note when you want to remember why.
           </Text>
         </Stack>
 

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -4,15 +4,15 @@ import { usePathname } from "next/navigation";
 import { Badge, Box, Container, HStack, SimpleGrid, Stack, Text } from "@chakra-ui/react";
 
 const routeNotes: Record<string, string> = {
-  "/": "Deck open. Draw slowly and save only what still feels useful tomorrow.",
-  "/saved": "Library open. Notes stay private until you explicitly include them in a copied card.",
-  "/history": "Recent draws open. Live duplicates are filtered before a reserve draw appears.",
-  "/sources": "Source notes open. Attribution is part of the product, not a legal footnote.",
+  "/": "Deck open. Take a fresh pull and keep only the lines you would want to see again.",
+  "/saved": "Library open. Saved cards and private notes are here when you want to revisit them.",
+  "/history": "Recent draws open. Skim what surfaced lately and keep anything worth another look.",
+  "/sources": "Sources open. See where each card comes from and when the reserve steps in.",
 };
 
 function resolveRouteNote(pathname: string): string {
   if (pathname.startsWith("/copy/")) {
-    return "Copy view open. Source text stays intact, and notes remain hidden unless you opt in.";
+    return "Copy view open. Take a clean, attributed copy and include your note only if you want to.";
   }
 
   return routeNotes[pathname] ?? routeNotes["/"];
@@ -42,10 +42,10 @@ export function SiteFooter() {
                 Advicely
               </Badge>
               <Text mt={4} fontSize="2xl" fontWeight="700" color="paper.50">
-                Random advice and quotes with enough honesty to be worth keeping.
+                A good line at the right moment is worth keeping.
               </Text>
               <Text mt={3} color="paper.100">
-                The deck stays close to the original source text, keeps attribution visible, and leaves your private notes in the browser unless you choose otherwise.
+                Pull something fresh, save what resonates, and leave yourself a note when it helps. The app keeps attribution close and your private notes local.
               </Text>
             </Box>
 

--- a/components/sources/source-guide.tsx
+++ b/components/sources/source-guide.tsx
@@ -10,10 +10,10 @@ export function SourceGuide() {
             Source notes
           </Badge>
           <Heading as="h1" fontSize={{ base: "4xl", md: "6xl" }} color="ink.800" lineHeight="0.96">
-            Where the deck comes from.
+            Where the cards come from.
           </Heading>
           <Text color="ink.600" fontSize={{ base: "md", md: "lg" }}>
-            Advicely is a transparent draw deck for random advice and quotes. It does not tailor live source content to your situation, and it does not present itself as professional guidance.
+            These pulls are random, not tailored. Advicely helps you save, note, and revisit them without obscuring where they came from.
           </Text>
         </Stack>
 
@@ -66,7 +66,7 @@ export function SourceGuide() {
         <Box bg="ink.800" color="paper.50" borderRadius="panel" p={6} shadow="float">
           <Heading as="h2" size="lg">Use judgment</Heading>
           <Text mt={3} color="paper.100">
-            Advicely is for reflection, curation, and lightweight sharing. It is not medical, legal, financial, crisis, or otherwise professional advice.
+            Advicely is for reflection and curation. It is not medical, legal, financial, crisis, or otherwise professional advice.
           </Text>
         </Box>
       </Stack>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -44,3 +44,8 @@
 - What went wrong: The honesty-first rewrite still kept “share” naming in routes, storage, and docs even after the product had become a local copy flow.
 - Root cause: Semantic cleanup stopped at the visible UI layer instead of tracing the concept through route contracts, persistence, and task documentation.
 - Prevention rule: When a product term changes, run a repo-wide terminology sweep across routes, storage contracts, docs, and tests before final verification.
+
+## 2026-03-05
+- What went wrong: The homepage and supporting copy started explaining internal product constraints instead of leading with user value.
+- Root cause: Internal alignment language from the honesty-first rewrite leaked into hero and footer copy without a separate plain-language value pass.
+- Prevention rule: For any marketing-facing surface, keep the headline and subhead focused on what the user gets in one sentence, then push trust or implementation details into secondary copy.

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -56,7 +56,7 @@ test("honesty-first draw flow works without console errors", async ({ page }) =>
   await page.keyboard.press("Tab");
   await expect(page.getByRole("link", { name: /skip to main content/i })).toBeFocused();
 
-  await expect(page.getByRole("heading", { name: /premium draw deck for random advice and quotes/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /find a line worth keeping/i })).toBeVisible();
   await page.getByRole("button", { name: /quote deck/i }).click();
   await page.getByRole("button", { name: /draw a card/i }).click();
 


### PR DESCRIPTION
## Summary
- replace internal-feeling hero/footer/source copy with user-facing value language
- keep honesty and provenance in secondary surfaces instead of the main headline
- update the homepage e2e assertion and record the copy lesson in repo notes

## Verification
- `pnpm run lint`
- `pnpm run test:e2e`
- `pnpm run check`