### PR TITLE
Polish Advicely metadata copy

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,18 +17,18 @@ const bodyFont = DM_Sans({
 });
 
 export const metadata: Metadata = {
-  title: "Advicely | Random Advice and Quotes",
-  description: "Draw random advice or quotes, keep personal notes locally, and save what is worth revisiting.",
+  title: "Advicely | Find a Line Worth Keeping",
+  description: "Draw a piece of advice or a quote, save the ones that stick, and keep a private note when you want to remember why.",
   metadataBase: new URL("https://advicely.vercel.app"),
   openGraph: {
-    title: "Advicely | Random Advice and Quotes",
-    description: "An honesty-first deck for random advice, quotes, and local note-taking.",
+    title: "Advicely | Find a Line Worth Keeping",
+    description: "Draw a piece of advice or a quote, save what resonates, and keep a private note for later.",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Advicely | Random Advice and Quotes",
-    description: "Random advice and quotes, clearly sourced and easy to save.",
+    title: "Advicely | Find a Line Worth Keeping",
+    description: "Draw a piece of advice or a quote, save what resonates, and keep a private note for later.",
   },
 };
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -49,3 +49,8 @@
 - What went wrong: The homepage and supporting copy started explaining internal product constraints instead of leading with user value.
 - Root cause: Internal alignment language from the honesty-first rewrite leaked into hero and footer copy without a separate plain-language value pass.
 - Prevention rule: For any marketing-facing surface, keep the headline and subhead focused on what the user gets in one sentence, then push trust or implementation details into secondary copy.
+
+## 2026-03-05
+- What went wrong: The page metadata kept older internal-facing product wording after the visible homepage copy had already been simplified.
+- Root cause: Metadata was treated as technical setup instead of part of the same user-facing copy surface as the hero and social preview text.
+- Prevention rule: Whenever headline copy changes, update `Metadata`, Open Graph, and Twitter text in the same patch and verify the rendered title on production.


### PR DESCRIPTION
## Summary
- update browser title and social metadata to match the simpler user-facing homepage copy
- treat metadata as product copy, not internal implementation text
- record the copy-surface lesson in repo notes

## Verification
- `pnpm run check`