### PR TITLE
Add centralized toasts and route polish

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,10 @@ body {
   font-family: var(--font-body), "Helvetica Neue", sans-serif;
 }
 
+main {
+  isolation: isolate;
+}
+
 body::before {
   content: "";
   position: fixed;
@@ -69,6 +73,42 @@ h4 {
   color: #17120d;
 }
 
+@keyframes route-frame-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes nav-card-pulse {
+  0% {
+    transform: translateX(-105%);
+    opacity: 0;
+  }
+
+  20% {
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateX(105%);
+    opacity: 0;
+  }
+}
+
+.route-frame-enter {
+  animation: route-frame-enter 220ms ease-out;
+}
+
+.nav-card-pulse {
+  animation: nav-card-pulse 900ms ease-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -77,5 +117,10 @@ h4 {
     animation-iteration-count: 1 !important;
     transition-duration: 1ms !important;
     scroll-behavior: auto !important;
+  }
+
+  .route-frame-enter,
+  .nav-card-pulse {
+    animation: none !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { DM_Sans, Fraunces } from "next/font/google";
 import { Providers } from "@/components/providers";
+import { RouteFrame } from "@/components/route-frame";
 import { SiteFooter } from "@/components/site-footer";
 import "./globals.css";
 
@@ -40,7 +41,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           Skip to main content
         </a>
         <Providers>
-          {children}
+          <RouteFrame>{children}</RouteFrame>
           <SiteFooter />
         </Providers>
       </body>

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import NextLink from "next/link";
+import { useLinkStatus } from "next/link";
 import type { Route } from "next";
 import { usePathname } from "next/navigation";
 import { Box, HStack, Icon, SimpleGrid, Stack, Text } from "@chakra-ui/react";
@@ -53,6 +54,70 @@ function isActive(pathname: string, href: Route): boolean {
   return pathname === href;
 }
 
+function NavCardContent({ item, active }: { item: NavItem; active: boolean }) {
+  const { pending } = useLinkStatus();
+
+  return (
+    <Box
+      position="relative"
+      overflow="hidden"
+      borderRadius="1.25rem"
+      borderWidth="1px"
+      borderColor={active ? "rgba(61, 126, 90, 0.35)" : pending ? "rgba(217, 90, 30, 0.26)" : "rgba(54, 46, 34, 0.12)"}
+      bg={active ? "rgba(79, 154, 113, 0.14)" : pending ? "rgba(255, 244, 236, 0.92)" : "rgba(255, 250, 240, 0.86)"}
+      shadow={active || pending ? "float" : "none"}
+      px={{ base: 4, md: 4 }}
+      py={{ base: 4, md: 4 }}
+      minH={{ base: "5.75rem", md: "6.5rem" }}
+      transition="transform 140ms ease, box-shadow 220ms ease, border-color 140ms ease, background-color 220ms ease"
+      _hover={{ transform: "translateY(-2px)", shadow: "float" }}
+    >
+      <Box
+        position="absolute"
+        top="0"
+        left="0"
+        right="0"
+        h="2px"
+        overflow="hidden"
+        bg={active ? "rgba(79, 154, 113, 0.24)" : pending ? "rgba(217, 90, 30, 0.18)" : "transparent"}
+      >
+        {pending ? (
+          <Box
+            className="nav-card-pulse"
+            bg="ember.400"
+            h="100%"
+            w="45%"
+            borderRadius="full"
+          />
+        ) : active ? (
+          <Box bg="accent.400" h="100%" w="100%" />
+        ) : null}
+      </Box>
+
+      <HStack align="flex-start" gap={3}>
+        <Box
+          borderRadius="999px"
+          bg={active ? "accent.700" : pending ? "ember.400" : "paper.200"}
+          color={active || pending ? "paper.50" : "ink.700"}
+          p={2}
+          flexShrink={0}
+          transition="background-color 180ms ease, color 180ms ease"
+        >
+          <Icon as={item.icon} boxSize={4.5} />
+        </Box>
+        <Stack gap={0.5} flex="1">
+          <Text fontWeight="700" color="ink.800">
+            {item.title}
+          </Text>
+          <Text fontSize="sm" color="ink.600" display={{ base: "none", sm: "block" }}>
+            {pending ? `Opening ${item.title.toLowerCase()}...` : item.description}
+          </Text>
+        </Stack>
+      </HStack>
+    </Box>
+  );
+}
+
 export function AppNav() {
   const pathname = usePathname();
 
@@ -63,38 +128,7 @@ export function AppNav() {
 
         return (
           <NextLink key={item.href} href={item.href} style={{ textDecoration: "none" }} aria-current={active ? "page" : undefined}>
-            <Box
-              borderRadius="1.25rem"
-              borderWidth="1px"
-              borderColor={active ? "rgba(61, 126, 90, 0.35)" : "rgba(54, 46, 34, 0.12)"}
-              bg={active ? "rgba(79, 154, 113, 0.14)" : "rgba(255, 250, 240, 0.86)"}
-              shadow={active ? "float" : "none"}
-              px={{ base: 4, md: 4 }}
-              py={{ base: 4, md: 4 }}
-              minH={{ base: "5.75rem", md: "6.5rem" }}
-              transition="transform 140ms ease, box-shadow 220ms ease, border-color 140ms ease"
-              _hover={{ transform: "translateY(-2px)", shadow: "float" }}
-            >
-              <HStack align="flex-start" gap={3}>
-                <Box
-                  borderRadius="999px"
-                  bg={active ? "accent.700" : "paper.200"}
-                  color={active ? "paper.50" : "ink.700"}
-                  p={2}
-                  flexShrink={0}
-                >
-                  <Icon as={item.icon} boxSize={4.5} />
-                </Box>
-                <Stack gap={0.5}>
-                  <Text fontWeight="700" color="ink.800">
-                    {item.title}
-                  </Text>
-                  <Text fontSize="sm" color="ink.600" display={{ base: "none", sm: "block" }}>
-                    {item.description}
-                  </Text>
-                </Stack>
-              </HStack>
-            </Box>
+            <NavCardContent item={item} active={active} />
           </NextLink>
         );
       })}

--- a/components/copy/copy-experience.tsx
+++ b/components/copy/copy-experience.tsx
@@ -6,6 +6,7 @@ import { Badge, Box, Button, Checkbox, Container, Heading, HStack, Icon, Spinner
 import { FiCopy } from "react-icons/fi";
 import { AppNav } from "@/components/app-nav";
 import { SourceCardView } from "@/components/source-card";
+import { notifyError, notifySuccess } from "@/features/feedback/notify";
 import { buildCopyCardText } from "@/features/library/copy-text";
 import type { CopyCardVM } from "@/features/library/contracts";
 import { getCopyCardById } from "@/features/library/storage";
@@ -16,7 +17,6 @@ interface CopyExperienceProps {
 
 export function CopyExperience({ copyId }: CopyExperienceProps) {
   const [copyCard, setCopyCard] = useState<CopyCardVM | null | undefined>(undefined);
-  const [copyMessage, setCopyMessage] = useState<string | null>(null);
   const [includeNote, setIncludeNote] = useState(false);
 
   useEffect(() => {
@@ -30,11 +30,15 @@ export function CopyExperience({ copyId }: CopyExperienceProps) {
 
     try {
       await navigator.clipboard.writeText(buildCopyCardText(copyCard, includeNote));
-      setCopyMessage("Copied to clipboard.");
-      setTimeout(() => setCopyMessage(null), 1800);
+      notifySuccess({
+        title: "Copied to clipboard",
+        description: includeNote ? "Your private note was included in this copy." : "Your private note stayed out of this copy.",
+      });
     } catch {
-      setCopyMessage("Clipboard unavailable in this browser.");
-      setTimeout(() => setCopyMessage(null), 1800);
+      notifyError({
+        title: "Clipboard unavailable",
+        description: "Try copying from a browser tab with clipboard access enabled.",
+      });
     }
   }
 
@@ -88,7 +92,6 @@ export function CopyExperience({ copyId }: CopyExperienceProps) {
                     <Text>Copy card text</Text>
                   </HStack>
                 </Button>
-                {copyMessage ? <Text role="status" color="accent.700">{copyMessage}</Text> : null}
               </Stack>
             }
           />

--- a/components/draw/draw-studio.tsx
+++ b/components/draw/draw-studio.tsx
@@ -20,6 +20,7 @@ import {
 import { FiBookmark, FiCopy, FiEye, FiRefreshCw, FiShuffle } from "react-icons/fi";
 import { AppNav } from "@/components/app-nav";
 import { SourceCardView } from "@/components/source-card";
+import { notifyError, notifyInfo, notifySuccess } from "@/features/feedback/notify";
 import {
   type DrawMode,
   type DrawRequestVM,
@@ -86,7 +87,6 @@ export function DrawStudio() {
   const [mode, setMode] = useState<DrawMode>("mixed");
   const [latestResponse, setLatestResponse] = useState<DrawResponseVM | null>(null);
   const [noteDraft, setNoteDraft] = useState("");
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [snapshot, setSnapshot] = useState<LibrarySnapshot>({ historyCount: 0, savedCount: 0 });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -113,7 +113,6 @@ export function DrawStudio() {
   }, [latestCard, savedCard]);
 
   async function handleDraw() {
-    setStatusMessage(null);
     setIsLoading(true);
     updatePreferences(mode);
 
@@ -130,9 +129,18 @@ export function DrawStudio() {
         historyCount: nextState.history.length,
         savedCount: nextState.savedCards.length,
       });
-      setStatusMessage(response.card.provenance === "live" ? "Fresh draw ready." : "Reserve draw ready.");
+      notifySuccess({
+        title: response.card.provenance === "live" ? "Fresh draw ready" : "Reserve draw ready",
+        description:
+          response.card.provenance === "live"
+            ? `${response.card.sourceLabel} delivered a new ${response.card.kind}.`
+            : "The reserve stepped in because a live pull did not clear the deck rules.",
+      });
     } catch (error) {
-      setStatusMessage(error instanceof Error ? error.message : "Could not draw a new card right now.");
+      notifyError({
+        title: "Could not draw a new card",
+        description: error instanceof Error ? error.message : "Try again in a moment.",
+      });
     } finally {
       setIsLoading(false);
     }
@@ -145,7 +153,10 @@ export function DrawStudio() {
 
     const nextState = saveCard(latestCard, noteDraft);
     setSnapshot((current) => ({ ...current, savedCount: nextState.savedCards.length }));
-    setStatusMessage(cardSaved ? "Saved note updated." : "Card saved to your library.");
+    notifySuccess({
+      title: cardSaved ? "Library card updated" : "Saved to your library",
+      description: cardSaved ? "Your local note changed." : "The card is now waiting in your library.",
+    });
   }
 
   function handleOpenCopyView() {
@@ -154,6 +165,10 @@ export function DrawStudio() {
     }
 
     const copyCard = createCopyCard(latestCard, noteDraft);
+    notifyInfo({
+      title: "Copy view ready",
+      description: "Attribution stays visible there, and your note stays optional.",
+    });
     router.push(`/copy/${copyCard.id}` as Route);
   }
 
@@ -349,9 +364,6 @@ export function DrawStudio() {
               </Box>
             )}
 
-            <Box role="status" aria-live="polite" minH="1.5rem">
-              {statusMessage ? <Text color="ink.600">{statusMessage}</Text> : null}
-            </Box>
           </Stack>
         </SimpleGrid>
       </Stack>

--- a/components/history/history-timeline.tsx
+++ b/components/history/history-timeline.tsx
@@ -9,6 +9,7 @@ import { AppNav } from "@/components/app-nav";
 import { SourceCardView } from "@/components/source-card";
 import type { SourceCardKind, SourceCardVM } from "@/features/draw/contracts";
 import { getCardEyebrow } from "@/features/draw/presentation";
+import { notifyInfo, notifySuccess } from "@/features/feedback/notify";
 import { matchesTextQuery } from "@/features/library/query";
 import { createCopyCard, getLibraryState, saveCard } from "@/features/library/storage";
 
@@ -36,10 +37,18 @@ export function HistoryTimeline() {
   function handleSave(card: SourceCardVM) {
     const nextState = saveCard(card);
     setSavedHashes(new Set(nextState.savedCards.map((saved) => saved.textHash)));
+    notifySuccess({
+      title: "Saved to your library",
+      description: "You can add a private note from the library whenever you want.",
+    });
   }
 
   function handleOpenCopyView(card: SourceCardVM) {
     const copyCard = createCopyCard(card);
+    notifyInfo({
+      title: "Copy view ready",
+      description: "You can copy the card text there with attribution intact.",
+    });
     router.push(`/copy/${copyCard.id}` as Route);
   }
 

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -3,11 +3,17 @@
 import type { ReactNode } from "react";
 import { ChakraProvider } from "@chakra-ui/react";
 import { advicelySystem } from "@/components/theme-system";
+import { AppToaster } from "@/components/ui/toaster";
 
 interface ProvidersProps {
   children: ReactNode;
 }
 
 export function Providers({ children }: ProvidersProps) {
-  return <ChakraProvider value={advicelySystem}>{children}</ChakraProvider>;
+  return (
+    <ChakraProvider value={advicelySystem}>
+      {children}
+      <AppToaster />
+    </ChakraProvider>
+  );
 }

--- a/components/route-frame.tsx
+++ b/components/route-frame.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Box } from "@chakra-ui/react";
+import { usePathname } from "next/navigation";
+
+interface RouteFrameProps {
+  children: ReactNode;
+}
+
+export function RouteFrame({ children }: RouteFrameProps) {
+  const pathname = usePathname();
+
+  return (
+    <Box key={pathname} className="route-frame-enter" data-route-frame={pathname} minH="100%">
+      {children}
+    </Box>
+  );
+}

--- a/components/saved/saved-library.tsx
+++ b/components/saved/saved-library.tsx
@@ -8,6 +8,7 @@ import { FiCopy, FiSearch, FiTrash2 } from "react-icons/fi";
 import { AppNav } from "@/components/app-nav";
 import { SourceCardView } from "@/components/source-card";
 import type { DrawSource, SourceCardKind } from "@/features/draw/contracts";
+import { notifyInfo, notifySuccess } from "@/features/feedback/notify";
 import type { SavedCardVM } from "@/features/library/contracts";
 import { matchesTextQuery } from "@/features/library/query";
 import { createCopyCard, getLibraryState, removeSavedCard, updateSavedCardNote } from "@/features/library/storage";
@@ -35,10 +36,18 @@ export function SavedLibrary() {
   function handleRemove(cardId: string) {
     const nextState = removeSavedCard(cardId);
     setSavedCards(nextState.savedCards);
+    notifySuccess({
+      title: "Removed from your library",
+      description: "The card is still available in recent draws if you need it again.",
+    });
   }
 
   function handleOpenCopyView(card: SavedCardVM) {
     const copyCard = createCopyCard(card, card.note);
+    notifyInfo({
+      title: "Copy view ready",
+      description: "The copy view keeps the source attached and leaves your note optional.",
+    });
     router.push(`/copy/${copyCard.id}` as Route);
   }
 

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  Box,
+  HStack,
+  Icon,
+  Portal,
+  Stack,
+  Text,
+  ToastCloseTrigger,
+  ToastDescription,
+  ToastIndicator,
+  ToastRoot,
+  ToastTitle,
+  Toaster,
+  createToaster,
+} from "@chakra-ui/react";
+import { FiArrowUpRight } from "react-icons/fi";
+
+export const toaster = createToaster({
+  placement: "top-end",
+  max: 3,
+  pauseOnPageIdle: true,
+  offsets: { top: "1.25rem", right: "1.25rem", left: "1rem", bottom: "1rem" },
+});
+
+export function AppToaster() {
+  return (
+    <Portal>
+      <Toaster toaster={toaster} insetInline={{ base: "1rem", md: "1.5rem" }}>
+        {(toast) => (
+          <ToastRoot
+            width={{ base: "calc(100vw - 2rem)", sm: "24rem" }}
+            borderRadius="1.25rem"
+            borderWidth="1px"
+            borderColor="rgba(54, 46, 34, 0.12)"
+            bg="rgba(255, 250, 240, 0.96)"
+            color="ink.800"
+            shadow="float"
+            backdropFilter="blur(18px)"
+          >
+            <HStack align="flex-start" gap={3} p={4}>
+              <Box
+                borderRadius="999px"
+                bg={toast.type === "error" ? "ember.100" : toast.type === "success" ? "accent.100" : "paper.200"}
+                color={toast.type === "error" ? "ember.700" : toast.type === "success" ? "accent.700" : "ink.700"}
+                p={2}
+                flexShrink={0}
+              >
+                {toast.type === "info" ? <Icon as={FiArrowUpRight} boxSize={4} /> : <ToastIndicator />}
+              </Box>
+
+              <Stack gap={1} flex="1">
+                {toast.title ? (
+                  <ToastTitle>
+                    <Text fontWeight="700" color="ink.800">
+                      {toast.title}
+                    </Text>
+                  </ToastTitle>
+                ) : null}
+                {toast.description ? (
+                  <ToastDescription>
+                    <Text color="ink.600" fontSize="sm">
+                      {toast.description}
+                    </Text>
+                  </ToastDescription>
+                ) : null}
+              </Stack>
+
+              <ToastCloseTrigger color="ink.500" mt={0.5} />
+            </HStack>
+          </ToastRoot>
+        )}
+      </Toaster>
+    </Portal>
+  );
+}

--- a/features/feedback/notify.ts
+++ b/features/feedback/notify.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { toaster } from "@/components/ui/toaster";
+
+interface NotifyOptions {
+  title: string;
+  description?: string;
+}
+
+export function notifySuccess(options: NotifyOptions) {
+  toaster.success({
+    ...options,
+    meta: { closable: true },
+  });
+}
+
+export function notifyError(options: NotifyOptions) {
+  toaster.error({
+    ...options,
+    meta: { closable: true },
+  });
+}
+
+export function notifyInfo(options: NotifyOptions) {
+  toaster.info({
+    ...options,
+    meta: { closable: true },
+  });
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -54,3 +54,8 @@
 - What went wrong: The page metadata kept older internal-facing product wording after the visible homepage copy had already been simplified.
 - Root cause: Metadata was treated as technical setup instead of part of the same user-facing copy surface as the hero and social preview text.
 - Prevention rule: Whenever headline copy changes, update `Metadata`, Open Graph, and Twitter text in the same patch and verify the rendered title on production.
+
+## 2026-03-05
+- What went wrong: Final verification briefly produced another false lint failure during the toast and transition pass.
+- Root cause: `check` and Playwright were launched in parallel again, and Playwright rotated `test-results` while ESLint was traversing the repo.
+- Prevention rule: For Advicely final evidence, run `check` first and `test:e2e` second in separate commands, never in the same parallel batch.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -104,3 +104,26 @@
   - `/saved` loaded with no console messages
   - `/history` loaded with no console messages
   - previous CSP `unsafe-eval` issue was eliminated after removing runtime Zod from the client bundle
+
+## 2026-03-05 Toast + Transition Polish
+- [x] Add a centralized Chakra toast system instead of per-screen inline status text
+- [x] Route draw/save/copy feedback through shared toast helpers so action feedback stays consistent
+- [x] Add cleaner route/nav motion without introducing App Router hacks or duplicated pending state
+- [x] Update browser coverage for the new feedback surfaces
+- [x] Re-run the repo verification ladder and local production browser QA
+
+### Toast + Transition Polish Verification Log
+- Context7 references used before implementation:
+  - Chakra UI toast guidance for `createToaster` singleton setup and app-level `Toaster` rendering
+  - Chakra UI `Presence`/transition guidance for entry animation constraints
+  - Next.js App Router guidance for supported navigation feedback patterns (`useLinkStatus`, `loading.tsx`-style route feedback constraints)
+- `pnpm run lint` (pass)
+- `pnpm run typecheck` (pass)
+- `pnpm run test` (pass)
+- `pnpm run test:e2e` (pass)
+- `pnpm run check` (pass)
+- Chrome DevTools MCP on local production build `http://127.0.0.1:3102`:
+  - `/` loaded with no console warnings or errors
+  - draw success toast rendered with live-source detail
+  - save toast rendered after moving a card into the library
+  - `/saved` route loaded cleanly after navigation with no console warnings or errors

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -66,17 +66,19 @@ test("honesty-first draw flow works without console errors", async ({ page }) =>
 
   await page.getByLabel(/optional personal note/i).fill("Keep this around for bad meetings.");
   await page.getByRole("button", { name: /open copy view/i }).click();
+  await expect(page.getByText(/copy view ready/i)).toBeVisible();
   await expect(page).toHaveURL(/\/copy\//);
   await expect(page.getByRole("heading", { name: /copy card/i })).toBeVisible();
   await page.getByText(/include private note when copying/i).click();
   await page.getByRole("button", { name: /copy card text/i }).click();
-  await expect(page.getByRole("status")).toHaveText(/copied to clipboard/i);
+  await expect(page.getByText(/copied to clipboard/i)).toBeVisible();
   await expect(page.getByText(/keep this around for bad meetings/i)).toBeVisible();
 
   await page.goto("/");
   await page.getByRole("button", { name: /draw a card/i }).click();
   await page.getByLabel(/optional personal note/i).fill("Keep this around for bad meetings.");
   await page.getByRole("button", { name: /save to library/i }).click();
+  await expect(page.getByText(/saved to your library/i)).toBeVisible();
   await page.getByRole("link", { name: /library/i }).click();
 
   await expect(page.getByRole("heading", { name: /your library/i })).toBeVisible();


### PR DESCRIPTION
## Summary
- add a shared Chakra toaster and feedback helpers instead of per-screen inline status text
- add route-shell and nav pending polish for smoother navigation without App Router hacks
- cover the new feedback surface in e2e and record the verification pass in tasks

## Verification
- pnpm run check
- pnpm run test:e2e
- Chrome DevTools MCP on local production build (draw toast, save toast, /saved nav, console clean)
