### PR TITLE
Tighten Advicely mobile home shell

### DIFF
--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -122,16 +122,68 @@ export function AppNav() {
   const pathname = usePathname();
 
   return (
-    <SimpleGrid columns={{ base: 2, md: 4 }} gap={3}>
-      {navItems.map((item) => {
-        const active = isActive(pathname, item.href);
+    <>
+      <HStack
+        display={{ base: "flex", md: "none" }}
+        gap={2}
+        overflowX="auto"
+        pb={1}
+        pr={1}
+        css={{
+          scrollbarWidth: "none",
+          WebkitOverflowScrolling: "touch",
+          msOverflowStyle: "none",
+        }}
+      >
+        {navItems.map((item) => {
+          const active = isActive(pathname, item.href);
 
-        return (
-          <NextLink key={item.href} href={item.href} style={{ textDecoration: "none" }} aria-current={active ? "page" : undefined}>
-            <NavCardContent item={item} active={active} />
-          </NextLink>
-        );
-      })}
-    </SimpleGrid>
+          return (
+            <NextLink key={item.href} href={item.href} style={{ textDecoration: "none", flexShrink: 0 }} aria-current={active ? "page" : undefined}>
+              <Box
+                position="relative"
+                overflow="hidden"
+                borderRadius="999px"
+                borderWidth="1px"
+                borderColor={active ? "rgba(61, 126, 90, 0.35)" : "rgba(54, 46, 34, 0.12)"}
+                bg={active ? "rgba(79, 154, 113, 0.14)" : "rgba(255, 250, 240, 0.88)"}
+                px={3.5}
+                py={2.5}
+                minW="fit-content"
+                transition="transform 140ms ease, box-shadow 220ms ease, border-color 140ms ease, background-color 220ms ease"
+                _hover={{ transform: "translateY(-1px)", shadow: "sm" }}
+              >
+                <HStack gap={2}>
+                  <Box
+                    borderRadius="999px"
+                    bg={active ? "accent.700" : "paper.200"}
+                    color={active ? "paper.50" : "ink.700"}
+                    p={1.5}
+                    flexShrink={0}
+                  >
+                    <Icon as={item.icon} boxSize={3.5} />
+                  </Box>
+                  <Text fontSize="sm" fontWeight="700" color="ink.800">
+                    {item.title}
+                  </Text>
+                </HStack>
+              </Box>
+            </NextLink>
+          );
+        })}
+      </HStack>
+
+      <SimpleGrid display={{ base: "none", md: "grid" }} columns={4} gap={3}>
+        {navItems.map((item) => {
+          const active = isActive(pathname, item.href);
+
+          return (
+            <NextLink key={item.href} href={item.href} style={{ textDecoration: "none" }} aria-current={active ? "page" : undefined}>
+              <NavCardContent item={item} active={active} />
+            </NextLink>
+          );
+        })}
+      </SimpleGrid>
+    </>
   );
 }

--- a/components/draw/draw-studio.tsx
+++ b/components/draw/draw-studio.tsx
@@ -7,6 +7,7 @@ import {
   Badge,
   Box,
   Button,
+  ButtonGroup,
   Container,
   Heading,
   HStack,
@@ -57,6 +58,12 @@ const heroSignals = [
     title: "Source included",
     body: "Every card keeps its attribution so you always know whether it came from a live source or the reserve.",
   },
+] as const;
+
+const mobileHighlights = [
+  "Advice and quotes on one clean deck.",
+  "Save only what is worth revisiting.",
+  "Attribution stays attached.",
 ] as const;
 
 interface LibrarySnapshot {
@@ -185,9 +192,30 @@ export function DrawStudio() {
           <Text color="ink.600" fontSize={{ base: "md", md: "lg" }} maxW="3xl">
             Draw a piece of advice or a quote, save the ones that stick, and keep a private note when you want to remember why.
           </Text>
+
+          <Box
+            display={{ base: "block", md: "none" }}
+            bg="rgba(255, 250, 240, 0.82)"
+            borderRadius="1.25rem"
+            borderWidth="1px"
+            borderColor="rgba(54, 46, 34, 0.1)"
+            px={4}
+            py={3}
+          >
+            <Stack gap={2}>
+              {mobileHighlights.map((highlight) => (
+                <HStack key={highlight} gap={2} align="flex-start">
+                  <Box mt="0.42rem" boxSize="0.4rem" borderRadius="full" bg="accent.500" flexShrink={0} />
+                  <Text color="ink.600" fontSize="sm">
+                    {highlight}
+                  </Text>
+                </HStack>
+              ))}
+            </Stack>
+          </Box>
         </Stack>
 
-        <SimpleGrid columns={{ base: 1, md: 3 }} gap={3}>
+        <SimpleGrid display={{ base: "none", md: "grid" }} columns={3} gap={3}>
           {heroSignals.map((signal) => (
             <Box
               key={signal.title}
@@ -232,7 +260,29 @@ export function DrawStudio() {
                   <Text fontSize="sm" textTransform="uppercase" letterSpacing="0.12em" color="ink.500" mb={3}>
                     Draw mode
                   </Text>
-                  <Stack gap={3}>
+                  <ButtonGroup attached display={{ base: "flex", md: "none" }} width="100%">
+                    {modeOptions.map((option) => (
+                      <Button
+                        key={option}
+                        flex="1"
+                        minH="3.25rem"
+                        borderRadius="0"
+                        variant={mode === option ? "solid" : "outline"}
+                        bg={mode === option ? "accent.700" : "rgba(255, 255, 255, 0.72)"}
+                        color={mode === option ? "paper.50" : "ink.700"}
+                        borderColor="rgba(54, 46, 34, 0.16)"
+                        onClick={() => setMode(option)}
+                      >
+                        <Text fontWeight="700">{getModeLabel(option)}</Text>
+                      </Button>
+                    ))}
+                  </ButtonGroup>
+
+                  <Text display={{ base: "block", md: "none" }} mt={3} color="ink.600" fontSize="sm">
+                    {getModeDescription(mode)}
+                  </Text>
+
+                  <Stack display={{ base: "none", md: "flex" }} gap={3}>
                     {modeOptions.map((option) => (
                       <Button
                         key={option}
@@ -257,19 +307,19 @@ export function DrawStudio() {
                 </Box>
 
                 <SimpleGrid columns={2} gap={3}>
-                  <Box bg="rgba(255,255,255,0.68)" borderRadius="1rem" p={4} borderWidth="1px" borderColor="rgba(54, 46, 34, 0.12)">
+                  <Box bg="rgba(255,255,255,0.68)" borderRadius="1rem" p={{ base: 3, md: 4 }} borderWidth="1px" borderColor="rgba(54, 46, 34, 0.12)">
                     <Text fontSize="xs" textTransform="uppercase" letterSpacing="0.12em" color="ink.500">
                       Recent
                     </Text>
-                    <Text fontSize="3xl" fontWeight="700" color="ink.800">
+                    <Text fontSize={{ base: "2xl", md: "3xl" }} fontWeight="700" color="ink.800">
                       {snapshot.historyCount}
                     </Text>
                   </Box>
-                  <Box bg="rgba(255,255,255,0.68)" borderRadius="1rem" p={4} borderWidth="1px" borderColor="rgba(54, 46, 34, 0.12)">
+                  <Box bg="rgba(255,255,255,0.68)" borderRadius="1rem" p={{ base: 3, md: 4 }} borderWidth="1px" borderColor="rgba(54, 46, 34, 0.12)">
                     <Text fontSize="xs" textTransform="uppercase" letterSpacing="0.12em" color="ink.500">
                       Library
                     </Text>
-                    <Text fontSize="3xl" fontWeight="700" color="ink.800">
+                    <Text fontSize={{ base: "2xl", md: "3xl" }} fontWeight="700" color="ink.800">
                       {snapshot.savedCount}
                     </Text>
                   </Box>
@@ -290,7 +340,7 @@ export function DrawStudio() {
                   </HStack>
                 </Button>
 
-                <Text color="ink.600" fontSize="sm">
+                <Text color="ink.600" fontSize="sm" display={{ base: "none", md: "block" }}>
                   Advice pulls come from AdviceSlip. Quote pulls come from ZenQuotes. Reserve draws only appear when a live pull fails, repeats, or returns unusable text.
                 </Text>
               </Stack>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -127,3 +127,23 @@
   - draw success toast rendered with live-source detail
   - save toast rendered after moving a card into the library
   - `/saved` route loaded cleanly after navigation with no console warnings or errors
+
+## 2026-03-05 Mobile Real-Estate Tightening
+- [x] Reduce the amount of non-essential explanation above the fold on the home route
+- [x] Replace the mobile 2x2 nav block with a compact horizontal rail
+- [x] Compress mobile draw-mode selection into a tighter single-choice control
+- [x] Re-verify the mobile shell in a production build
+
+### Mobile Real-Estate Tightening Verification Log
+- Context7 references used before implementation:
+  - Chakra UI segmented control and compact button-group patterns for single-choice mobile controls
+- `pnpm run lint` (pass)
+- `pnpm run typecheck` (pass)
+- `pnpm run test` (pass)
+- `pnpm run build` (pass)
+- `pnpm run test:e2e` (pass)
+- Chrome DevTools MCP on local production build `http://127.0.0.1:3103` at `390x844`:
+  - homepage now shows compact summary bullets instead of three stacked signal cards
+  - nav now renders as a horizontal rail instead of a two-row grid
+  - draw mode now renders as a compact single-choice control with a short helper line
+  - no console warnings or errors


### PR DESCRIPTION
## Summary
- reduce non-essential mobile copy above the fold on the home route
- convert the mobile nav into a horizontal rail and compress draw mode into a compact single-choice control
- keep the desktop shell intact while improving mobile first-screen focus

## Verification
- pnpm run lint
- pnpm run typecheck
- pnpm run test
- pnpm run build
- pnpm run test:e2e
- pnpm run check
- Chrome DevTools MCP on local production build at 390x844
