### PR TITLE
Remove client Zod from Advicely library storage

### DIFF
--- a/features/library/contracts.ts
+++ b/features/library/contracts.ts
@@ -1,38 +1,30 @@
-import { z } from "zod";
-import { drawModeSchema, sourceCardVMSchema } from "@/features/draw/contracts";
+import type { DrawMode, SourceCardVM } from "@/features/draw/contracts";
 
-const noteSchema = z
-  .string()
-  .trim()
-  .max(320)
-  .optional()
-  .transform((value) => (value && value.length > 0 ? value : undefined));
+export interface SavedCardVM extends SourceCardVM {
+  savedAt: string;
+  note?: string;
+}
 
-export const savedCardVMSchema = sourceCardVMSchema.extend({
-  savedAt: z.string().datetime(),
-  note: noteSchema,
-});
+export interface CopyCardVM {
+  id: string;
+  createdAt: string;
+  card: SourceCardVM;
+  note?: string;
+}
 
-export const copyCardVMSchema = z.object({
-  id: z.string().min(1),
-  createdAt: z.string().datetime(),
-  card: sourceCardVMSchema,
-  note: noteSchema,
-});
+export interface LibraryPreferencesVM {
+  lastMode: DrawMode;
+}
 
-export const libraryPreferencesSchema = z.object({
-  lastMode: drawModeSchema,
-});
+export interface LibraryStateVM {
+  version: 6;
+  history: SourceCardVM[];
+  savedCards: SavedCardVM[];
+  copyCards: CopyCardVM[];
+  preferences: LibraryPreferencesVM;
+}
 
-export const libraryStateVMSchema = z.object({
-  version: z.literal(6),
-  history: z.array(sourceCardVMSchema).max(160),
-  savedCards: z.array(savedCardVMSchema).max(240),
-  copyCards: z.array(copyCardVMSchema).max(120),
-  preferences: libraryPreferencesSchema,
-});
-
-export const emptyLibraryState: z.infer<typeof libraryStateVMSchema> = {
+export const emptyLibraryState: LibraryStateVM = {
   version: 6,
   history: [],
   savedCards: [],
@@ -41,8 +33,3 @@ export const emptyLibraryState: z.infer<typeof libraryStateVMSchema> = {
     lastMode: "mixed",
   },
 };
-
-export type SavedCardVM = z.infer<typeof savedCardVMSchema>;
-export type CopyCardVM = z.infer<typeof copyCardVMSchema>;
-export type LibraryPreferencesVM = z.infer<typeof libraryPreferencesSchema>;
-export type LibraryStateVM = z.infer<typeof libraryStateVMSchema>;

--- a/features/library/storage.ts
+++ b/features/library/storage.ts
@@ -7,10 +7,122 @@ import {
   type LibraryStateVM,
   type SavedCardVM,
   type CopyCardVM,
-  libraryStateVMSchema,
 } from "@/features/library/contracts";
 
 const STORAGE_KEY = "advicely:v6:library";
+const CARD_KINDS = new Set(["advice", "quote"] as const);
+const SOURCES = new Set(["advice_slip", "zen_quotes", "advicely_reserve"] as const);
+const PROVENANCES = new Set(["live", "fallback"] as const);
+const FALLBACK_REASONS = new Set(["provider_unavailable", "invalid_payload", "filtered", "duplicate"] as const);
+const DRAW_MODES = new Set(["advice", "quote", "mixed"] as const);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isIsoString(value: unknown): value is string {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function isSourceCard(value: unknown): value is SourceCardVM {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    CARD_KINDS.has(value.kind as SourceCardVM["kind"]) &&
+    typeof value.text === "string" &&
+    value.text.length >= 4 &&
+    (value.author === undefined || typeof value.author === "string") &&
+    SOURCES.has(value.source as SourceCardVM["source"]) &&
+    typeof value.sourceLabel === "string" &&
+    value.sourceLabel.length > 0 &&
+    PROVENANCES.has(value.provenance as SourceCardVM["provenance"]) &&
+    (value.fallbackReason === undefined || FALLBACK_REASONS.has(value.fallbackReason as NonNullable<SourceCardVM["fallbackReason"]>)) &&
+    typeof value.textHash === "string" &&
+    /^[a-f0-9]{64}$/.test(value.textHash) &&
+    isIsoString(value.drawnAt)
+  );
+}
+
+function isSavedCard(value: unknown): value is SavedCardVM {
+  if (!isObject(value) || !isSourceCard(value)) {
+    return false;
+  }
+
+  const candidate = value as SavedCardVM;
+  return isIsoString(candidate.savedAt) && (candidate.note === undefined || typeof candidate.note === "string");
+}
+
+function isCopyCard(value: unknown): value is CopyCardVM {
+  return (
+    isObject(value) &&
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    isIsoString(value.createdAt) &&
+    isSourceCard(value.card) &&
+    (value.note === undefined || typeof value.note === "string")
+  );
+}
+
+function sanitizeSourceCard(card: SourceCardVM): SourceCardVM {
+  return {
+    ...card,
+    author: typeof card.author === "string" && card.author.trim().length > 0 ? card.author : undefined,
+    fallbackReason: card.provenance === "fallback" ? card.fallbackReason : undefined,
+  };
+}
+
+function sanitizeSavedCard(card: SavedCardVM): SavedCardVM {
+  return {
+    ...sanitizeSourceCard(card),
+    savedAt: card.savedAt,
+    note: normalizeNote(card.note),
+  };
+}
+
+function sanitizeCopyCard(card: CopyCardVM): CopyCardVM {
+  return {
+    id: card.id,
+    createdAt: card.createdAt,
+    card: sanitizeSourceCard(card.card),
+    note: normalizeNote(card.note),
+  };
+}
+
+function parseLibraryState(value: unknown): LibraryStateVM {
+  if (!isObject(value)) {
+    return emptyLibraryState;
+  }
+
+  if (value.version !== 6) {
+    return emptyLibraryState;
+  }
+
+  if (!Array.isArray(value.history) || !Array.isArray(value.savedCards) || !Array.isArray(value.copyCards) || !isObject(value.preferences)) {
+    return emptyLibraryState;
+  }
+
+  if (!DRAW_MODES.has(value.preferences.lastMode as DrawMode)) {
+    return emptyLibraryState;
+  }
+
+  const history = value.history.filter(isSourceCard).map(sanitizeSourceCard).slice(0, 160);
+  const savedCards = value.savedCards.filter(isSavedCard).map(sanitizeSavedCard).slice(0, 240);
+  const copyCards = value.copyCards.filter(isCopyCard).map(sanitizeCopyCard).slice(0, 120);
+
+  return {
+    version: 6,
+    history,
+    savedCards,
+    copyCards,
+    preferences: {
+      lastMode: value.preferences.lastMode as DrawMode,
+    },
+  };
+}
 
 function normalizeNote(note?: string): string | undefined {
   const normalized = note?.trim().slice(0, 320);
@@ -36,8 +148,7 @@ function readState(): LibraryStateVM {
       return emptyLibraryState;
     }
 
-    const parsed = libraryStateVMSchema.safeParse(JSON.parse(raw));
-    return parsed.success ? parsed.data : emptyLibraryState;
+    return parseLibraryState(JSON.parse(raw));
   } catch {
     return emptyLibraryState;
   }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -59,3 +59,8 @@
 - What went wrong: Final verification briefly produced another false lint failure during the toast and transition pass.
 - Root cause: `check` and Playwright were launched in parallel again, and Playwright rotated `test-results` while ESLint was traversing the repo.
 - Prevention rule: For Advicely final evidence, run `check` first and `test:e2e` second in separate commands, never in the same parallel batch.
+
+## 2026-03-05
+- What went wrong: Production CSP still reported a blocked `eval` path even after earlier client-side Zod cleanup.
+- Root cause: The browser-side library storage module still imported Zod-backed contract modules, which shipped Zod's JIT `Function(...)` path into the client bundle.
+- Prevention rule: Keep browser storage and client guards on plain TypeScript/manual validation only; any Zod schema module imported by a client file must be treated as a bundle leak and removed from that path.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -147,3 +147,28 @@
   - nav now renders as a horizontal rail instead of a two-row grid
   - draw mode now renders as a compact single-choice control with a short helper line
   - no console warnings or errors
+
+## 2026-03-05 CSP Eval Cleanup
+- [x] Reproduce the reported production CSP `eval` issue against the shipped chunk path
+- [x] Trace the client-side import path that still bundled Zod JIT code
+- [x] Remove Zod from the browser storage/contracts path without weakening CSP
+- [x] Rebuild and verify that the app route chunks no longer contain the offending path
+
+### CSP Eval Cleanup Verification Log
+- Production investigation:
+  - confirmed live CSP header on `https://advicely.vercel.app` does not allow `'unsafe-eval'`
+  - confirmed DevTools report referenced an older shipped chunk `932-2ece2dd6ed9d039d.js`
+  - confirmed that chunk contained Zod JIT code with `Function("")`
+- Fix:
+  - replaced browser-side `features/library/contracts.ts` Zod contracts with plain TypeScript interfaces
+  - replaced `libraryStateVMSchema.safeParse(...)` in `features/library/storage.ts` with manual guards/sanitizers
+- Verification:
+  - `pnpm run lint` (pass)
+  - `pnpm run typecheck` (pass)
+  - `pnpm run test` (pass)
+  - `pnpm run build` (pass)
+  - `pnpm run test:e2e` (pass)
+  - rebuilt client route chunks checked clean:
+    - `.next/static/chunks/app/page-*.js` has no `zod`, `Function(`, or `unsafe-eval`
+    - `.next/static/chunks/app/saved/page-*.js` has no `zod`, `Function(`, or `unsafe-eval`
+    - `.next/static/chunks/app/history/page-*.js` has no `zod`, `Function(`, or `unsafe-eval`


### PR DESCRIPTION
## Summary
- remove Zod-backed contracts from the browser storage path
- replace local storage parsing with manual guards so production CSP no longer trips on Zod JIT code
- document the root cause and verification evidence in tasks

## Verification
- pnpm run check
- pnpm run test:e2e
- inspected rebuilt route chunks for zod / Function paths
- verified live CSP header does not allow unsafe-eval
