### PR TITLE
Refresh Advicely final sweep notes

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -18,7 +18,7 @@
 ## 2026-03-04
 - What went wrong: Dev runtime produced a Chakra hydration mismatch after switching to Turbopack mode.
 - Root cause: Emotion style injection order in this stack can diverge under Turbopack dev hydration.
-- Prevention rule: Keep both `next dev --webpack` and `next build --webpack` for this repo, then verify the production build in DevTools before finalizing UI work.
+- Prevention rule: If a styling/runtime stack fights the platform defaults, re-evaluate the primitive layer instead of pinning the whole repo to a fallback bundler, then verify the production build in DevTools before finalizing UI work.
 
 ## 2026-03-04
 - What went wrong: Advice cards surfaced non-practical quote content and generic warning labels that confused normal users.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -178,7 +178,7 @@
 - [x] Replace the Chakra shell with static CSS primitives and a local toast system
 - [x] Restore default Next 16 `dev` and `build` scripts
 - [x] Re-verify the app under a Turbopack production build
-- [ ] Recheck the deployed production app after merge
+- [x] Recheck the deployed production app after merge
 
 ### Runtime Styling Migration Findings
 - Chakra was the only meaningful reason the repo stayed on webpack for both development and production.
@@ -200,3 +200,17 @@
   - `/saved` loaded with no console messages
   - `/sources` loaded with no console messages
   - draw flow, local copy flow, and navigation rendered cleanly under the Turbopack build
+ - Production recheck on `https://advicely.vercel.app` after merge:
+   - Vercel production deploy for merge commit `2b5b7a15a19b3c9b0f3aa92f6ec6958bd593c3e9` completed successfully
+   - public production alias serves the new Turbopack chunk graph
+   - fresh browser session on `/` is console-clean
+
+## 2026-03-05 Final Sweep
+- [x] Re-scan repo guidance, docs, tasks, and dependency/output residue after the runtime migration
+- [x] Remove stale generated artifacts from the workspace
+- [x] Correct any stale operational guidance discovered during the sweep
+
+### Final Sweep Findings
+- Removed leftover Playwright `test-results/` residue from the working tree.
+- Updated the outdated webpack-only lesson so it matches the current Turbopack-first architecture.
+- Reconfirmed that the only available dependency major upgrade is `eslint 10`, which remains intentionally deferred for current Next plugin peer compatibility.


### PR DESCRIPTION
## Summary
- update stale operational notes after the runtime migration
- mark the deployed production recheck complete
- record the final sweep cleanup results

## Verification
- verified no generated residue remains under the repo root scan
- verified task and lesson files now match the current Turbopack-first architecture
- confirmed only eslint 10 remains available and intentionally deferred