### PR TITLE
feat: upgrade social metadata and add minimalist brand card

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Request body:
 }
 ```
 
+## Social Metadata and Brand Assets
+
+- Metadata is defined in [`app/layout.tsx`](./app/layout.tsx) with canonical URL, Open Graph, and Twitter cards.
+- Dynamic social image routes:
+  - `/opengraph-image` (`1200x630` PNG)
+  - `/twitter-image` (`1200x630` PNG)
+- Branded static card source (for portfolio/docs):
+  - [`public/social/advicely-card.svg`](./public/social/advicely-card.svg)
+
 Response body:
 
 ```json

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,18 +18,52 @@ const bodyFont = DM_Sans({
 });
 
 export const metadata: Metadata = {
-  title: "Advicely | Find a Line Worth Keeping",
-  description: "Draw a piece of advice or a quote, save the ones that stick, and keep a private note when you want to remember why.",
+  title: {
+    default: "Advicely | Draw Advice and Quotes",
+    template: "%s | Advicely",
+  },
+  description:
+    "Draw advice and quote cards from live sources, save what resonates, and keep optional notes private in your browser.",
   metadataBase: new URL("https://advicely.vercel.app"),
+  alternates: {
+    canonical: "/",
+  },
+  icons: {
+    icon: "/icon",
+    apple: "/apple-icon",
+  },
   openGraph: {
-    title: "Advicely | Find a Line Worth Keeping",
-    description: "Draw a piece of advice or a quote, save what resonates, and keep a private note for later.",
+    title: "Advicely | Draw Advice and Quotes",
+    description:
+      "Draw advice and quote cards from live sources, save what resonates, and keep optional notes private in your browser.",
+    url: "/",
+    siteName: "Advicely",
+    locale: "en_US",
     type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Advicely social preview card showing Draw advice and quotes with a calm neutral visual style",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Advicely | Find a Line Worth Keeping",
-    description: "Draw a piece of advice or a quote, save what resonates, and keep a private note for later.",
+    title: "Advicely | Draw Advice and Quotes",
+    description:
+      "Draw advice and quote cards from live sources, save what resonates, and keep optional notes private in your browser.",
+    images: [
+      {
+        url: "/twitter-image",
+        alt: "Advicely social preview card showing Draw advice and quotes with source aware framing",
+      },
+    ],
+  },
+  robots: {
+    index: true,
+    follow: true,
   },
 };
 

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og";
 
+export const alt = "Advicely social preview showing advice and quote draw experience";
+
 export const size = {
   width: 1200,
   height: 630,
@@ -17,21 +19,78 @@ export default function OpenGraphImage() {
           display: "flex",
           flexDirection: "column",
           justifyContent: "space-between",
-          padding: "64px",
+          padding: "56px",
           background:
-            "radial-gradient(circle at 12% 8%, rgba(79,154,113,0.18), transparent 26%), radial-gradient(circle at 88% 0%, rgba(246,117,52,0.16), transparent 24%), linear-gradient(180deg, #fffaf1, #f3ead6)",
+            "radial-gradient(circle at 10% 8%, rgba(90, 130, 108, 0.2), transparent 28%), radial-gradient(circle at 88% 6%, rgba(190, 150, 88, 0.18), transparent 30%), linear-gradient(180deg, #f8f4e9, #efe8d7)",
           color: "#17120d",
           fontFamily: "DM Sans",
         }}
       >
-        <div style={{ fontSize: 26, letterSpacing: "0.12em", textTransform: "uppercase", opacity: 0.72 }}>
-          Advicely v6
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            width: "100%",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 24,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              opacity: 0.8,
+            }}
+          >
+            Advicely
+          </div>
+          <div
+            style={{
+              display: "flex",
+              padding: "10px 18px",
+              borderRadius: 999,
+              border: "1px solid rgba(23,18,13,0.16)",
+              fontSize: 18,
+              letterSpacing: "0.04em",
+              color: "#2b231b",
+            }}
+          >
+            Advice + Quotes
+          </div>
         </div>
-        <div style={{ fontSize: 68, lineHeight: 1.02, maxWidth: 980, fontWeight: 700 }}>
-          Random advice and quotes, clearly sourced.
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 24,
+            maxWidth: 980,
+          }}
+        >
+          <div style={{ fontSize: 72, lineHeight: 1.01, fontWeight: 700 }}>
+            Draw advice and quotes that are easy to keep.
+          </div>
+          <div style={{ fontSize: 32, lineHeight: 1.25, opacity: 0.88, maxWidth: 920 }}>
+            Pull from live sources, save what resonates, and keep optional notes private on your device.
+          </div>
         </div>
-        <div style={{ fontSize: 30, opacity: 0.84, maxWidth: 760 }}>
-          Draw, save, and revisit what matters. Personal notes stay local to your browser.
+        <div
+          style={{
+            display: "flex",
+            gap: 14,
+            alignItems: "center",
+            fontSize: 22,
+            color: "#2f2a23",
+          }}
+        >
+          <div style={{ display: "flex", padding: "10px 14px", borderRadius: 12, background: "rgba(255,255,255,0.58)" }}>
+            Source aware
+          </div>
+          <div style={{ display: "flex", padding: "10px 14px", borderRadius: 12, background: "rgba(255,255,255,0.58)" }}>
+            Local notes
+          </div>
+          <div style={{ display: "flex", padding: "10px 14px", borderRadius: 12, background: "rgba(255,255,255,0.58)" }}>
+            Fast draw flow
+          </div>
         </div>
       </div>
     ),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,13 @@ interface LibraryStateVM {
 }
 ```
 
+## Metadata and Share Surfaces
+
+- Root metadata in `app/layout.tsx` includes canonical URL and Open Graph/Twitter configuration.
+- `app/opengraph-image.tsx` is the canonical dynamic social image route.
+- `app/twitter-image.tsx` reuses the same image implementation to keep share visuals consistent.
+- `public/social/advicely-card.svg` is the static brand card for docs and portfolio placements.
+
 ## Guardrails
 
 - Provider content is displayed as normalized source text, not rewritten guidance.

--- a/public/social/advicely-card.svg
+++ b/public/social/advicely-card.svg
@@ -1,0 +1,26 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Advicely social card">
+  <defs>
+    <linearGradient id="base" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8F4E9"/>
+      <stop offset="1" stop-color="#EFE8D7"/>
+    </linearGradient>
+    <radialGradient id="aura" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(104 84) rotate(36) scale(300 200)">
+      <stop stop-color="#5C8A69" stop-opacity="0.24"/>
+      <stop offset="1" stop-color="#5C8A69" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#base)"/>
+  <rect width="1200" height="630" fill="url(#aura)"/>
+  <rect x="64" y="62" width="146" height="44" rx="22" fill="#18120D"/>
+  <text x="95" y="90" fill="#F4EEDF" font-size="22" font-family="Arial, sans-serif">Advicely</text>
+  <text x="64" y="270" fill="#16110D" font-size="96" font-weight="700" font-family="Georgia, serif">Find a line worth</text>
+  <text x="64" y="360" fill="#16110D" font-size="96" font-weight="700" font-family="Georgia, serif">keeping.</text>
+  <text x="64" y="430" fill="#3B3228" font-size="36" font-family="Arial, sans-serif">Advice and quote cards with clear source attribution.</text>
+  <rect x="64" y="488" width="182" height="48" rx="24" fill="#E8E0CF" stroke="#CBBFA9"/>
+  <rect x="262" y="488" width="164" height="48" rx="24" fill="#E8E0CF" stroke="#CBBFA9"/>
+  <rect x="442" y="488" width="170" height="48" rx="24" fill="#E8E0CF" stroke="#CBBFA9"/>
+  <text x="95" y="519" fill="#2F2922" font-size="24" font-family="Arial, sans-serif">Source aware</text>
+  <text x="293" y="519" fill="#2F2922" font-size="24" font-family="Arial, sans-serif">Local notes</text>
+  <text x="474" y="519" fill="#2F2922" font-size="24" font-family="Arial, sans-serif">Quick draw</text>
+  <line x1="64" y1="560.5" x2="1136" y2="560.5" stroke="#CFC3AE"/>
+</svg>

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -79,3 +79,8 @@
 - What went wrong: Homepage signal icons and footer information cards shipped with inconsistent visual alignment and low-contrast badge treatment in dark surfaces.
 - Root cause: Shared flex utility composition and panel spacing assumptions leaked into specialized sections without a dedicated contrast/layout QA pass.
 - Prevention rule: For every homepage/footer change, run a targeted UI audit for icon baseline alignment, explicit container layout (`display` + `gap`), and WCAG AA contrast thresholds before final verification.
+
+## 2026-03-06
+- What went wrong: Social media assets were prepared from manual viewport screenshots, which introduced framing artifacts and inconsistent crop quality.
+- Root cause: We treated portfolio image export as a visual task only instead of using metadata-native Open Graph assets as the canonical source.
+- Prevention rule: For share previews, always update and verify `app/opengraph-image.tsx` plus metadata image tags first, then generate any portfolio exports from those OG endpoints.


### PR DESCRIPTION
## Summary\n- upgrade Next metadata for canonical, Open Graph, and Twitter cards\n- refine dynamic social image route composition and alt metadata\n- add minimalist branded SVG social card asset\n- document social metadata and brand asset surfaces in README and architecture docs\n- record lessons entry for metadata-first social workflow\n\n## Verification\n- pnpm run check\n- pnpm run docs:check