### PR TITLE
chore: patch smol-toml advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   ],
   "pnpm": {
     "overrides": {
+      "markdownlint-cli2>smol-toml": "^1.6.1",
       "micromatch>picomatch": "^2.3.2",
       "vitest>picomatch": "^4.0.4"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  markdownlint-cli2>smol-toml: ^1.6.1
   micromatch>picomatch: ^2.3.2
   vitest>picomatch: ^4.0.4
 
@@ -1116,8 +1117,8 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -1924,7 +1925,7 @@ snapshots:
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.0)
       micromatch: 4.0.8
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2287,7 +2288,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- override markdownlint-cli2's transitive smol-toml dependency to 1.6.1
- refresh the lockfile to remove the new medium Dependabot advisory

## Verification
- pnpm run check
- pnpm run audit:high