### PR TITLE
chore: group dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,31 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 3
+    groups:
+      production-dependencies:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        patterns:
+          - "*"
+      development-dependencies:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- reduce routine Dependabot PR volume by grouping version updates
- lower the npm and github-actions open PR limits to 3
- pin the weekly update window to Monday 09:00 America/Chicago

## Verification
- YAML parsed successfully with Ruby YAML.load_file
- security updates remain separate because only version updates are grouped